### PR TITLE
expose slice instead of passing

### DIFF
--- a/app/raycaster/src/CoordinatesStack/coordinatesStack.ts
+++ b/app/raycaster/src/CoordinatesStack/coordinatesStack.ts
@@ -6,7 +6,7 @@ class CoordinatesStack {
 	private stck: Array<Coordinates>;
 	private pool: ObjectPool<Coordinates>;
 	constructor(size: number = 1500) {
-		this.pool = new ObjectPool<Coordinates>(size, () => ({ x: -1, y: -1 }));
+		this.pool = new ObjectPool<Coordinates>(size, () => ({ x: -1, y: -1 }), true);
 		this.stck = new Array(size);
 		this.fillStack(this.stck, 0, size);
 	}

--- a/app/raycaster/src/batchCorrelator/batchCorrelator.ts
+++ b/app/raycaster/src/batchCorrelator/batchCorrelator.ts
@@ -38,7 +38,7 @@ class BatchCorrelator {
 
 	private appendAllMapWalls(): void {
 		this.batches.addMapWalls(this.gameMap.walls);
-		this.batches.addMapWalls(this.gameMap.playerTrail);
+		this.batches.addTrailWalls(this.gameMap.playerTrail);
 	}
 
 	private setRays(): void {

--- a/app/raycaster/src/batchCorrelator/batchCorrelator.ts
+++ b/app/raycaster/src/batchCorrelator/batchCorrelator.ts
@@ -70,16 +70,16 @@ class BatchCorrelator {
 	}
 
 	private appendGridSlice(): void {
-		const { gridHits } = this.gameMap.castRay(this.currentAngle, this.maxDistance);
-		for (let j = 0; j < gridHits.length; j++) {
-			this.appendGridPoint(gridHits[j]);
+		this.gameMap.castRay(this.currentAngle, this.maxDistance);
+		for (let j = 0; j < this.gameMap.currentSlice.gridHits.length; j++) {
+			this.appendGridPoint(this.gameMap.currentSlice.gridHits[j]);
 		}
 	}
 
 	private getAdjustedDistance(): { distance: number, color: ColorName } {
-		const { distance, color } = this.gameMap.castRay(this.currentAngle, this.maxDistance);
-		const correctedDistance = this.removeFishEye(distance);
-		return { distance: correctedDistance, color };
+		this.gameMap.castRay(this.currentAngle, this.maxDistance);
+		const correctedDistance = this.removeFishEye(this.gameMap.currentSlice.distance);
+		return { distance: correctedDistance, color: this.gameMap.currentSlice.color };
 	}
 
 	private removeFishEye(distance: number): number {

--- a/app/raycaster/src/batches/batches.ts
+++ b/app/raycaster/src/batches/batches.ts
@@ -1,4 +1,5 @@
 import { Coordinates, LineSegment } from "../geometry/interfaces";
+import { TrailInterface } from "../trail/interface";
 import { ColorName } from "../color/color_name";
 import { getColorKey, ColorKey } from "../color_key/color_key_cache";
 import { ObjectPool } from "../objectPool/objectPool";
@@ -39,7 +40,12 @@ class Batches {
 			this.addMapWall(wall);
 		}
 	}
-
+	addTrailWalls(trail: TrailInterface): void {
+		let cur = trail.head;
+		while (cur && cur.next) {
+			this.addMapWall({ color: trail.color, line: { start: cur, end: cur.next } });
+		}
+	}
 	addMapWall(wall: WallInterface): void {
 		const colorKey = getColorKey(wall.color, 1);
 		if (!this.mapBatches.has(colorKey)) {

--- a/app/raycaster/src/game/batchRenderer.ts
+++ b/app/raycaster/src/game/batchRenderer.ts
@@ -6,7 +6,7 @@ import { LineSegment } from '../geometry/interfaces';
 import { RaycasterInterface } from '../raycaster/interface';
 import { BrightnessInterface } from '../brightness/interface';
 import { ColorKey } from './color_key_cache';
-
+//some duplication here with batchCorrelator.ts, remove when compile and tests are clean
 class BatchCorrelator {
 	public batches: Batches;
 	private rays: Float32Array;
@@ -63,16 +63,16 @@ class BatchCorrelator {
 		angle: number,
 		index: number,
 	): void {
-		const { gridHits } = this._gameMap.castRay(angle, this.maxDistance);
-		for (let j = 0; j < gridHits.length; j++) {
-			this.appendGridPoint(gridHits[j], angle, index);
+		this._gameMap.castRay(angle, this.maxDistance);
+		for (let j = 0; j < this._gameMap.currentSlice.gridHits.length; j++) {
+			this.appendGridPoint(this._gameMap.currentSlice.gridHits[j], angle, index);
 		}
 	}
 
 	private getAdjustedDistance(angle: number): { distance: number, color: ColorName } {
-		const { distance, color } = this._gameMap.castRay(angle, this.maxDistance);
-		const correctedDistance = this.raycaster.removeFishEye(distance, angle, this._gameMap.playerAngle);
-		return { distance: correctedDistance, color };
+		this._gameMap.castRay(angle, this.maxDistance);
+		const correctedDistance = this.raycaster.removeFishEye(this._gameMap.currentSlice.distance, angle, this._gameMap.playerAngle);
+		return { distance: correctedDistance, color: this._gameMap.currentSlice.color };
 	}
 
 	private sliceHeight(

--- a/app/raycaster/src/game/batchRenderer.ts
+++ b/app/raycaster/src/game/batchRenderer.ts
@@ -1,105 +1,8 @@
 import { ContextRendererInterface } from '../renderer/interface';
 import { ColorName } from '../color/color_name';
-import { GameMapInterface } from '../gamemap/interface';
 import { Batches, BatchedRect } from '../batches/batches';
 import { LineSegment } from '../geometry/interfaces';
-import { RaycasterInterface } from '../raycaster/interface';
-import { BrightnessInterface } from '../brightness/interface';
 import { ColorKey } from './color_key_cache';
-//some duplication here with batchCorrelator.ts, remove when compile and tests are clean
-class BatchCorrelator {
-	public batches: Batches;
-	private rays: Float32Array;
-	private _gameMap: GameMapInterface;
-
-	constructor(
-		gameMap: GameMapInterface,
-		private raycaster: RaycasterInterface,
-		private maxDistance: number,
-		private horizonY: number,
-		private cameraHeight: number,
-		private wallHeight: number,
-		private brightness: BrightnessInterface,
-		private resolution: number
-	) {
-		this.rays = new Float32Array(resolution);
-		this.batches = new Batches();
-		this._gameMap = gameMap;
-	}
-
-	public batchRenderData(): void {
-		this.batches.clear();
-		if (!this.rays) this.rays = new Float32Array(this.resolution);
-		this.raycaster.fillRaysInto(this.rays, this._gameMap.playerAngle);
-
-		this.appendAllSlices();
-		this.batches.addMapWalls(this._gameMap.walls);
-		this.batches.addMapWalls(this._gameMap.playerTrail);
-	}
-
-	private appendAllSlices(): void {
-		for (let i = 0; i < this.rays.length; i++) {
-			this.appendSlice(i);
-		}
-	}
-
-	private appendSlice(index: number): void {
-		const angle = this.rays[index];
-		this.appendWallSlice(angle, index);
-		this.appendGridSlice(angle, index);
-	}
-
-	private appendWallSlice(
-		angle: number,
-		index: number,
-	): void {
-		const { distance, color } = this.getAdjustedDistance(angle);
-		const slice = this.sliceHeight(distance);
-		const wallBrightness = this.brightness.calculateBrightness(distance);
-		this.batches.addWallSlice(color, wallBrightness, index, slice.origin, slice.magnitude);
-	}
-
-	private appendGridSlice(
-		angle: number,
-		index: number,
-	): void {
-		this._gameMap.castRay(angle, this.maxDistance);
-		for (let j = 0; j < this._gameMap.currentSlice.gridHits.length; j++) {
-			this.appendGridPoint(this._gameMap.currentSlice.gridHits[j], angle, index);
-		}
-	}
-
-	private getAdjustedDistance(angle: number): { distance: number, color: ColorName } {
-		this._gameMap.castRay(angle, this.maxDistance);
-		const correctedDistance = this.raycaster.removeFishEye(this._gameMap.currentSlice.distance, angle, this._gameMap.playerAngle);
-		return { distance: correctedDistance, color: this._gameMap.currentSlice.color };
-	}
-
-	private sliceHeight(
-		distance: number,
-	): { origin: number, magnitude: number } {
-		const wallTopOffset = this.wallHeight - this.cameraHeight;
-		const wallBottomOffset = -this.cameraHeight;
-		const topY = this.horizonY - (wallTopOffset * this.raycaster.focalLength) / distance;
-		const bottomY = this.horizonY - (wallBottomOffset * this.raycaster.focalLength) / distance;
-		return { origin: topY, magnitude: bottomY - topY }
-	}
-
-	private appendGridPoint(
-		gridHit: number,
-		angle: number,
-		index: number,
-	): void {
-		const distance = this.raycaster.removeFishEye(gridHit, angle, this._gameMap.playerAngle);
-		const y = this.floorPoint(distance);
-		this.batches.addGridPoint({ x: index, y });
-	}
-
-	private floorPoint(distance: number): number {
-		const floorOffset = -this.cameraHeight;
-		return this.horizonY - (floorOffset * this.raycaster.focalLength) / distance;
-	}
-}
 
 class BatchRenderer {
 	private _batches: Batches = new Batches();
@@ -183,4 +86,4 @@ class BatchRenderer {
 		lines.forEach(line => this.contextRenderer.line(line));
 	}
 }
-export { BatchCorrelator, BatchRenderer };
+export { BatchRenderer };

--- a/app/raycaster/src/gamemap/interface.ts
+++ b/app/raycaster/src/gamemap/interface.ts
@@ -1,6 +1,6 @@
 import { Coordinates, LineSegment } from '../geometry/interfaces';
 import { ColorName } from '../color/color_name';
-
+import { TrailInterface } from '../trail/interface';
 interface WallInterface {
 	line: LineSegment;
 	color: ColorName
@@ -23,7 +23,7 @@ interface GameMapInterface {
 	gridLinesY: LineSegment[];
 	playerPosition: Coordinates;
 	playerAngle: number;
-	playerTrail: WallInterface[];
+	playerTrail: TrailInterface;
 	currentSlice: Slice;
 	castRay(angle: number, distance: number): void;
 	resetIntersections(): void;

--- a/app/raycaster/src/gamemap/interface.ts
+++ b/app/raycaster/src/gamemap/interface.ts
@@ -24,7 +24,8 @@ interface GameMapInterface {
 	playerPosition: Coordinates;
 	playerAngle: number;
 	playerTrail: WallInterface[];
-	castRay(angle: number, distance: number): Slice;
+	currentSlice: Slice;
+	castRay(angle: number, distance: number): void;
 	resetIntersections(): void;
 	appendWall(wall: WallInterface): void;
 }

--- a/app/raycaster/src/gamemap/map.test.tsx
+++ b/app/raycaster/src/gamemap/map.test.tsx
@@ -265,6 +265,7 @@ describe('GameMap.castRay()', () => {
 		];
 
 		const trail = new MockTrail({ x: 7, y: 2 });
+		trail.color = ColorName.RED;
 		trailInfo.forEach((point) => {
 			trail.append(point.x, point.y);
 		})

--- a/app/raycaster/src/gamemap/map.test.tsx
+++ b/app/raycaster/src/gamemap/map.test.tsx
@@ -5,19 +5,21 @@ import { Dimensions } from '../geometry/interfaces'
 import { ColorName } from '../color/color_name';
 import { Coordinates, LineSegment } from '../geometry/interfaces';
 import { PlayerInterface } from '../player/interface';
+import { TrailInterface } from '../trail/interface';
 
 class MockPlayer implements PlayerInterface {
 	x: number;
 	y: number;
 	angle: number;
-	trail: WallInterface[];
+	temp: WallInterface[];
 	color = ColorName.RED;
+	trail: TrailInterface = { head: { x: 0, y: 0 }, tail: { x: 0, y: 0 }, color: ColorName.RED, append: jest.fn() };
 
 	constructor(pos: Coordinates, angle: number, trail: WallInterface[]) {
 		this.x = pos.x;
 		this.y = pos.y;
 		this.angle = angle;
-		this.trail = trail;
+		this.temp = trail;
 	}
 
 	move(): void { }
@@ -156,7 +158,13 @@ describe("Player tests", () => {
 	beforeEach(() => {
 		player = {
 			turnLeft: jest.fn(() => { }), turnRight: jest.fn(), move: jest.fn(() => { }), x: 1, y: 1, angle: 0, color: ColorName.GREEN,
-			trail: []
+			temp: [],
+			trail: {
+				append: jest.fn(),
+				head: { x: 0, y: 0 },
+				tail: { x: 0, y: 0 },
+				color: ColorName.GREEN,
+			}
 		};
 	})
 	test("angle should be passed to player class", () => {

--- a/app/raycaster/src/gamemap/map.test.tsx
+++ b/app/raycaster/src/gamemap/map.test.tsx
@@ -40,219 +40,211 @@ class MockPlayer implements PlayerInterface {
 	turnRight(): void { }
 }
 
-// describe('GameMap basic map setup', () => {
-// 	let gameMap: GameMap;
-// 	beforeEach(() => {
-// 		gameMap = new GameMap(
-// 			{ height: 10, width: 10 },
-// 			ColorName.BLACK,
-// 			1,
-// 			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
-// 		);
-// 	});
-//
-// 	test('should initialize with 4 boundary walls', () => {
-// 		expect(gameMap.walls.length).toBe(4);
-// 	});
-//
-// 	test('should have correct boundary wall coordinates', () => {
-// 		const expectedLocations: LineSegment[] = [
-// 			{ start: { x: 0, y: 0 }, end: { x: 0, y: 10 } },
-// 			{ start: { x: 0, y: 0 }, end: { x: 10, y: 0 } },
-// 			{ start: { x: 10, y: 0 }, end: { x: 10, y: 10 } },
-// 			{ start: { x: 0, y: 10 }, end: { x: 10, y: 10 } }
-// 		];
-// 		expectedLocations.forEach(location => {
-// 			expect(gameMap.walls).toContainEqual(
-// 				expect.objectContaining({ line: location })
-// 			);
-// 		});
-// 	});
-// });
-//
-// describe('GameMap configuration options', () => {
-// 	test('walls should be configurable by color', () => {
-// 		const gameMap = new GameMap({ width: 10, height: 10 }, ColorName.RED, 1,
-// 			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
-// 		);
-//
-// 		gameMap.walls.forEach(wall => {
-// 			expect(wall.color).toBe(ColorName.RED);
-// 		});
-// 	});
-//
-// 	describe('gridline generation', () => {
-// 		let gameMap: GameMap;
-//
-// 		beforeEach(() => {
-// 			gameMap = new GameMap({ width: 10, height: 20 },
-// 				ColorName.RED,
-// 				1,
-// 				new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
-// 			);
-// 		});
-//
-// 		test('should initialize correct number of X gridlines', () => {
-// 			expect(gameMap.gridLinesX.length).toBe(10);
-// 		});
-//
-// 		test('should initialize correct number of Y gridlines', () => {
-// 			expect(gameMap.gridLinesY.length).toBe(20);
-// 		});
-// 	});
-// });
-//
-// describe('castRay method', () => {
-// 	let gameMap: GameMap;
-//
-// 	beforeEach(() => {
-// 		gameMap = new GameMap({ width: 10, height: 11 },
-// 			ColorName.GREEN,
-// 			1,
-// 			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
-// 		);
-// 	});
-//
-// 	test('should return correct distance when ray hits boundary wall directly (0°)', () => {
-// 		const expectedDistance = 9;
-// 		gameMap.castRay(0, 11);
-// 		expect(gameMap.currentSlice.distance).toBeCloseTo(expectedDistance, 5);
-// 	});
-//
-// 	test('should return correct distance when ray hits boundary at 45°', () => {
-// 		const expectedDistance = Math.sqrt((10 - 1) ** 2 + (11 - 1) ** 2);
-// 		gameMap.castRay(Math.atan2(10, 9), 20);
-// 		expect(gameMap.currentSlice.distance).toBeCloseTo(expectedDistance, 5);
-// 	});
-//
-// 	test('should return max distance if ray hits nothing (looking away from all walls)', () => {
-// 		gameMap = new GameMap({ width: 32, height: 11 }, ColorName.GREEN, 1,
-// 			new MockPlayer({ x: 16, y: 5 }, 0, new MockTrail({ x: 16, y: 5 }))
-// 		);
-// 		gameMap.castRay(Math.PI, 15); // Facing negative x direction
-// 		expect(gameMap.currentSlice.distance).toEqual(15);
-// 		expect(gameMap.currentSlice.color).toEqual(ColorName.NONE);
-// 	});
-//
-//
-// 	test('should return same point for zero-length ray', () => {
-// 		gameMap.castRay(0, 0);
-// 		expect(gameMap.currentSlice.distance).toEqual(0);
-// 		expect(gameMap.currentSlice.intersection).toEqual(gameMap.playerPosition);
-// 	});
-//
-// 	test('should return correct intersection for vertical ray', () => {
-// 		gameMap.castRay(Math.PI / 2, 11); // Upward
-// 		expect(gameMap.currentSlice.intersection.x).toBeCloseTo(1, 5);
-// 		expect(gameMap.currentSlice.intersection.y).toBeGreaterThan(1);
-// 	});
-//
-// 	test('should handle grazing corner case gracefully', () => {
-// 		gameMap = new GameMap({
-// 			width: 32,
-// 			height: 11
-// 		},
-// 			ColorName.GREEN,
-// 			1,
-// 			new MockPlayer({ x: 0.001, y: 0.001 }, 0, new MockTrail({ x: 0.001, y: 0.001 }))
-// 		);
-// 		gameMap.castRay(Math.PI, 11);
-// 		expect(gameMap.currentSlice.distance).toBeGreaterThan(0);
-// 	});
-//
-// 	test('should not crash on near-parallel ray to a wall', () => {
-// 		const epsilon = 1e-8;
-// 		gameMap.castRay(epsilon, 20);
-// 		expect(gameMap.currentSlice.distance).toBeGreaterThan(0);
-// 	});
-// });
-// describe("Player tests", () => {
-// 	let player: PlayerInterface;
-// 	beforeEach(() => {
-// 		player = {
-// 			turnLeft: jest.fn(() => { }), turnRight: jest.fn(), move: jest.fn(() => { }), x: 1, y: 1, angle: 0, color: ColorName.GREEN,
-// 			trail: {
-// 				append: jest.fn(),
-// 				head: { x: 0, y: 0 },
-// 				tail: { x: 0, y: 0 },
-// 				color: ColorName.GREEN,
-// 			}
-// 		};
-// 	})
-// 	test("angle should be passed to player class", () => {
-// 		const gameMap = new GameMap({ width: 10, height: 20 }, ColorName.RED, 1, player);
-// 		gameMap.turnPlayer(Math.PI / 2)
-// 		expect(player.turnLeft).toHaveBeenLastCalledWith()
-// 	})
-// 	test("movePlayer should call player.move", () => {
-// 		const gameMap = new GameMap({ width: 10, height: 20 }, ColorName.RED, 1, player);
-// 		gameMap.movePlayer()
-// 		expect(player.move).toHaveBeenCalled()
-// 	})
-// })
-//
-// describe('intialization tests', () => {
-// 	let dimensions: Dimensions
-// 	let color: ColorName
-// 	let grid_size: number
-// 	let player: PlayerInterface
-// 	beforeEach(() => {
-// 		dimensions = { width: 100, height: 200 }
-// 		color = ColorName.RED
-// 		grid_size = 5
-// 		player = new MockPlayer({ x: -1, y: -1 }, 0, new MockTrail({ x: -1, y: -1 }))
-// 	})
-//
-// 	test('game map may not intialize with player position touching walls: left', () => {
-// 		player.x = 0
-// 		player.y = 5
-// 		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
-// 	})
-//
-// 	test('game map may not intialize with player position touching walls: top', () => {
-// 		player.x = 5
-// 		player.y = 0
-// 		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
-// 	})
-//
-// 	test('game map may not intialize with player position touching walls: right', () => {
-// 		player.x = 100
-// 		player.y = 5
-// 		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
-// 	})
-//
-// 	test('game map may not intialize with player position touching walls: bottom', () => {
-// 		player.x = 4
-// 		player.y = 200
-// 		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
-// 	})
-// })
-//
+describe('GameMap basic map setup', () => {
+	let gameMap: GameMap;
+	beforeEach(() => {
+		gameMap = new GameMap(
+			{ height: 10, width: 10 },
+			ColorName.BLACK,
+			1,
+			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
+		);
+	});
+
+	test('should initialize with 4 boundary walls', () => {
+		expect(gameMap.walls.length).toBe(4);
+	});
+
+	test('should have correct boundary wall coordinates', () => {
+		const expectedLocations: LineSegment[] = [
+			{ start: { x: 0, y: 0 }, end: { x: 0, y: 10 } },
+			{ start: { x: 0, y: 0 }, end: { x: 10, y: 0 } },
+			{ start: { x: 10, y: 0 }, end: { x: 10, y: 10 } },
+			{ start: { x: 0, y: 10 }, end: { x: 10, y: 10 } }
+		];
+		expectedLocations.forEach(location => {
+			expect(gameMap.walls).toContainEqual(
+				expect.objectContaining({ line: location })
+			);
+		});
+	});
+});
+
+describe('GameMap configuration options', () => {
+	test('walls should be configurable by color', () => {
+		const gameMap = new GameMap({ width: 10, height: 10 }, ColorName.RED, 1,
+			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
+		);
+
+		gameMap.walls.forEach(wall => {
+			expect(wall.color).toBe(ColorName.RED);
+		});
+	});
+});
+
+describe('gridline generation', () => {
+	let gameMap: GameMap;
+
+	beforeEach(() => {
+		gameMap = new GameMap({ width: 10, height: 20 },
+			ColorName.RED,
+			1,
+			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
+		);
+	});
+
+	test('should initialize correct number of X gridlines', () => {
+		expect(gameMap.gridLinesX.length).toBe(10);
+	});
+
+	test('should initialize correct number of Y gridlines', () => {
+		expect(gameMap.gridLinesY.length).toBe(20);
+	});
+});
+
+describe('castRay method', () => {
+	let gameMap: GameMap;
+
+	beforeEach(() => {
+		gameMap = new GameMap({ width: 10, height: 11 },
+			ColorName.GREEN,
+			1,
+			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
+		);
+	});
+
+	test('should return correct distance when ray hits boundary wall directly (0°)', () => {
+		const expectedDistance = 9;
+		gameMap.castRay(0, 11);
+		expect(gameMap.currentSlice.distance).toBeCloseTo(expectedDistance, 5);
+	});
+
+	test('should return correct distance when ray hits boundary at 45°', () => {
+		const expectedDistance = Math.sqrt((10 - 1) ** 2 + (11 - 1) ** 2);
+		gameMap.castRay(Math.atan2(10, 9), 20);
+		expect(gameMap.currentSlice.distance).toBeCloseTo(expectedDistance, 5);
+	});
+
+	test('should return max distance if ray hits nothing (looking away from all walls)', () => {
+		gameMap = new GameMap({ width: 32, height: 11 }, ColorName.GREEN, 1,
+			new MockPlayer({ x: 16, y: 5 }, 0, new MockTrail({ x: 16, y: 5 }))
+		);
+		gameMap.castRay(Math.PI, 15); // Facing negative x direction
+		expect(gameMap.currentSlice.distance).toEqual(15);
+		expect(gameMap.currentSlice.color).toEqual(ColorName.NONE);
+	});
+
+
+	test('should return same point for zero-length ray', () => {
+		gameMap.castRay(0, 0);
+		expect(gameMap.currentSlice.distance).toEqual(0);
+		expect(gameMap.currentSlice.intersection).toEqual(gameMap.playerPosition);
+	});
+
+	test('should return correct intersection for vertical ray', () => {
+		gameMap.castRay(Math.PI / 2, 11); // Upward
+		expect(gameMap.currentSlice.intersection.x).toBeCloseTo(1, 5);
+		expect(gameMap.currentSlice.intersection.y).toBeGreaterThan(1);
+	});
+
+	test('should handle grazing corner case gracefully', () => {
+		gameMap = new GameMap({
+			width: 32,
+			height: 11
+		},
+			ColorName.GREEN,
+			1,
+			new MockPlayer({ x: 0.001, y: 0.001 }, 0, new MockTrail({ x: 0.001, y: 0.001 }))
+		);
+		gameMap.castRay(Math.PI, 11);
+		expect(gameMap.currentSlice.distance).toBeGreaterThan(0);
+	});
+
+	test('should not crash on near-parallel ray to a wall', () => {
+		const epsilon = 1e-8;
+		gameMap.castRay(epsilon, 20);
+		expect(gameMap.currentSlice.distance).toBeGreaterThan(0);
+	});
+});
+describe("Player tests", () => {
+	let player: PlayerInterface;
+	beforeEach(() => {
+		player = {
+			turnLeft: jest.fn(() => { }), turnRight: jest.fn(), move: jest.fn(() => { }), x: 1, y: 1, angle: 0, color: ColorName.GREEN,
+			trail: {
+				append: jest.fn(),
+				head: { x: 0, y: 0 },
+				tail: { x: 0, y: 0 },
+				color: ColorName.GREEN,
+			}
+		};
+	})
+	test("angle should be passed to player class", () => {
+		const gameMap = new GameMap({ width: 10, height: 20 }, ColorName.RED, 1, player);
+		gameMap.turnPlayer(Math.PI / 2)
+		expect(player.turnLeft).toHaveBeenLastCalledWith()
+	})
+	test("movePlayer should call player.move", () => {
+		const gameMap = new GameMap({ width: 10, height: 20 }, ColorName.RED, 1, player);
+		gameMap.movePlayer()
+		expect(player.move).toHaveBeenCalled()
+	})
+})
+
+describe('intialization tests', () => {
+	let dimensions: Dimensions
+	let color: ColorName
+	let grid_size: number
+	let player: PlayerInterface
+	beforeEach(() => {
+		dimensions = { width: 100, height: 200 }
+		color = ColorName.RED
+		grid_size = 5
+		player = new MockPlayer({ x: -1, y: -1 }, 0, new MockTrail({ x: -1, y: -1 }))
+	})
+
+	test('game map may not intialize with player position touching walls: left', () => {
+		player.x = 0
+		player.y = 5
+		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
+	})
+
+	test('game map may not intialize with player position touching walls: top', () => {
+		player.x = 5
+		player.y = 0
+		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
+	})
+
+	test('game map may not intialize with player position touching walls: right', () => {
+		player.x = 100
+		player.y = 5
+		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
+	})
+
+	test('game map may not intialize with player position touching walls: bottom', () => {
+		player.x = 4
+		player.y = 200
+		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
+	})
+})
+
 
 
 describe('GameMap.castRay()', () => {
-	// test("should not return a hit for the trail segment currently being drawn (trail head)", () => {
-	// 	const position = { x: 5, y: 5 };
-	// 	const directionAngle = Math.PI / 4; // right
-	//
-	// 	const mockTrailHead: WallInterface = {
-	// 		line: {
-	// 			start: { x: 1, y: 5 },
-	// 			end: { x: 5, y: 5 }
-	// 		},
-	// 		color: ColorName.RED// same as player's current position
-	// 	};
-	// 	const trail = new MockTrail(position);
-	// 	trail.head = { x: 1, y: 5 }; // Set the head to the same position as the mockTrailHead
-	//
-	// 	const player = new MockPlayer(position, directionAngle, trail);
-	// 	const map = new GameMap({ width: 50, height: 50 }, ColorName.BLACK, 10, player);
-	//
-	// 	map.castRay(directionAngle, 50);
-	//
-	// 	expect(map.currentSlice.distance).not.toBe(0);
-	// });
-	//
+	test("should not return a hit for the trail segment currently being drawn (trail head)", () => {
+		const position = { x: 5, y: 5 };
+		const directionAngle = Math.PI / 4; // right
+		const trail = new MockTrail(position);
+		trail.head = { x: 1, y: 5 }; // Set the head to the same position as the mockTrailHead
+
+		const player = new MockPlayer(position, directionAngle, trail);
+		const map = new GameMap({ width: 50, height: 50 }, ColorName.BLACK, 10, player);
+
+		map.castRay(directionAngle, 50);
+
+		expect(map.currentSlice.distance).not.toBe(0);
+	});
+
 	test("should detect player's own wall if from a tenable viewpoint", () => {
 		const position = { x: 5, y: 4 };
 		const directionAngle = 0

--- a/app/raycaster/src/gamemap/map.test.tsx
+++ b/app/raycaster/src/gamemap/map.test.tsx
@@ -16,8 +16,7 @@ class MockTrail implements TrailInterface {
 		this.tail = origin;
 	}
 	append(x: number, y: number): void {
-		const temp = { x, y };
-		this.head.next = temp;
+		const temp = { x, y, next: this.head };
 		this.head = temp;
 	}
 }
@@ -41,219 +40,219 @@ class MockPlayer implements PlayerInterface {
 	turnRight(): void { }
 }
 
-describe('GameMap basic map setup', () => {
-	let gameMap: GameMap;
-	beforeEach(() => {
-		gameMap = new GameMap(
-			{ height: 10, width: 10 },
-			ColorName.BLACK,
-			1,
-			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
-		);
-	});
-
-	test('should initialize with 4 boundary walls', () => {
-		expect(gameMap.walls.length).toBe(4);
-	});
-
-	test('should have correct boundary wall coordinates', () => {
-		const expectedLocations: LineSegment[] = [
-			{ start: { x: 0, y: 0 }, end: { x: 0, y: 10 } },
-			{ start: { x: 0, y: 0 }, end: { x: 10, y: 0 } },
-			{ start: { x: 10, y: 0 }, end: { x: 10, y: 10 } },
-			{ start: { x: 0, y: 10 }, end: { x: 10, y: 10 } }
-		];
-		expectedLocations.forEach(location => {
-			expect(gameMap.walls).toContainEqual(
-				expect.objectContaining({ line: location })
-			);
-		});
-	});
-});
-
-describe('GameMap configuration options', () => {
-	test('walls should be configurable by color', () => {
-		const gameMap = new GameMap({ width: 10, height: 10 }, ColorName.RED, 1,
-			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
-		);
-
-		gameMap.walls.forEach(wall => {
-			expect(wall.color).toBe(ColorName.RED);
-		});
-	});
-
-	describe('gridline generation', () => {
-		let gameMap: GameMap;
-
-		beforeEach(() => {
-			gameMap = new GameMap({ width: 10, height: 20 },
-				ColorName.RED,
-				1,
-				new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
-			);
-		});
-
-		test('should initialize correct number of X gridlines', () => {
-			expect(gameMap.gridLinesX.length).toBe(10);
-		});
-
-		test('should initialize correct number of Y gridlines', () => {
-			expect(gameMap.gridLinesY.length).toBe(20);
-		});
-	});
-});
-
-describe('castRay method', () => {
-	let gameMap: GameMap;
-
-	beforeEach(() => {
-		gameMap = new GameMap({ width: 10, height: 11 },
-			ColorName.GREEN,
-			1,
-			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
-		);
-	});
-
-	test('should return correct distance when ray hits boundary wall directly (0°)', () => {
-		const expectedDistance = 9;
-		gameMap.castRay(0, 11);
-		expect(gameMap.currentSlice.distance).toBeCloseTo(expectedDistance, 5);
-	});
-
-	test('should return correct distance when ray hits boundary at 45°', () => {
-		const expectedDistance = Math.sqrt((10 - 1) ** 2 + (11 - 1) ** 2);
-		gameMap.castRay(Math.atan2(10, 9), 20);
-		expect(gameMap.currentSlice.distance).toBeCloseTo(expectedDistance, 5);
-	});
-
-	test('should return max distance if ray hits nothing (looking away from all walls)', () => {
-		gameMap = new GameMap({ width: 32, height: 11 }, ColorName.GREEN, 1,
-			new MockPlayer({ x: 16, y: 5 }, 0, new MockTrail({ x: 16, y: 5 }))
-		);
-		gameMap.castRay(Math.PI, 15); // Facing negative x direction
-		expect(gameMap.currentSlice.distance).toEqual(15);
-		expect(gameMap.currentSlice.color).toEqual(ColorName.NONE);
-	});
-
-
-	test('should return same point for zero-length ray', () => {
-		gameMap.castRay(0, 0);
-		expect(gameMap.currentSlice.distance).toEqual(0);
-		expect(gameMap.currentSlice.intersection).toEqual(gameMap.playerPosition);
-	});
-
-	test('should return correct intersection for vertical ray', () => {
-		gameMap.castRay(Math.PI / 2, 11); // Upward
-		expect(gameMap.currentSlice.intersection.x).toBeCloseTo(1, 5);
-		expect(gameMap.currentSlice.intersection.y).toBeGreaterThan(1);
-	});
-
-	test('should handle grazing corner case gracefully', () => {
-		gameMap = new GameMap({
-			width: 32,
-			height: 11
-		},
-			ColorName.GREEN,
-			1,
-			new MockPlayer({ x: 0.001, y: 0.001 }, 0, new MockTrail({ x: 0.001, y: 0.001 }))
-		);
-		gameMap.castRay(Math.PI, 11);
-		expect(gameMap.currentSlice.distance).toBeGreaterThan(0);
-	});
-
-	test('should not crash on near-parallel ray to a wall', () => {
-		const epsilon = 1e-8;
-		gameMap.castRay(epsilon, 20);
-		expect(gameMap.currentSlice.distance).toBeGreaterThan(0);
-	});
-});
-describe("Player tests", () => {
-	let player: PlayerInterface;
-	beforeEach(() => {
-		player = {
-			turnLeft: jest.fn(() => { }), turnRight: jest.fn(), move: jest.fn(() => { }), x: 1, y: 1, angle: 0, color: ColorName.GREEN,
-			trail: {
-				append: jest.fn(),
-				head: { x: 0, y: 0 },
-				tail: { x: 0, y: 0 },
-				color: ColorName.GREEN,
-			}
-		};
-	})
-	test("angle should be passed to player class", () => {
-		const gameMap = new GameMap({ width: 10, height: 20 }, ColorName.RED, 1, player);
-		gameMap.turnPlayer(Math.PI / 2)
-		expect(player.turnLeft).toHaveBeenLastCalledWith()
-	})
-	test("movePlayer should call player.move", () => {
-		const gameMap = new GameMap({ width: 10, height: 20 }, ColorName.RED, 1, player);
-		gameMap.movePlayer()
-		expect(player.move).toHaveBeenCalled()
-	})
-})
-
-describe('intialization tests', () => {
-	let dimensions: Dimensions
-	let color: ColorName
-	let grid_size: number
-	let player: PlayerInterface
-	beforeEach(() => {
-		dimensions = { width: 100, height: 200 }
-		color = ColorName.RED
-		grid_size = 5
-		player = new MockPlayer({ x: -1, y: -1 }, 0, new MockTrail({ x: -1, y: -1 }))
-	})
-
-	test('game map may not intialize with player position touching walls: left', () => {
-		player.x = 0
-		player.y = 5
-		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
-	})
-
-	test('game map may not intialize with player position touching walls: top', () => {
-		player.x = 5
-		player.y = 0
-		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
-	})
-
-	test('game map may not intialize with player position touching walls: right', () => {
-		player.x = 100
-		player.y = 5
-		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
-	})
-
-	test('game map may not intialize with player position touching walls: bottom', () => {
-		player.x = 4
-		player.y = 200
-		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
-	})
-})
-
+// describe('GameMap basic map setup', () => {
+// 	let gameMap: GameMap;
+// 	beforeEach(() => {
+// 		gameMap = new GameMap(
+// 			{ height: 10, width: 10 },
+// 			ColorName.BLACK,
+// 			1,
+// 			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
+// 		);
+// 	});
+//
+// 	test('should initialize with 4 boundary walls', () => {
+// 		expect(gameMap.walls.length).toBe(4);
+// 	});
+//
+// 	test('should have correct boundary wall coordinates', () => {
+// 		const expectedLocations: LineSegment[] = [
+// 			{ start: { x: 0, y: 0 }, end: { x: 0, y: 10 } },
+// 			{ start: { x: 0, y: 0 }, end: { x: 10, y: 0 } },
+// 			{ start: { x: 10, y: 0 }, end: { x: 10, y: 10 } },
+// 			{ start: { x: 0, y: 10 }, end: { x: 10, y: 10 } }
+// 		];
+// 		expectedLocations.forEach(location => {
+// 			expect(gameMap.walls).toContainEqual(
+// 				expect.objectContaining({ line: location })
+// 			);
+// 		});
+// 	});
+// });
+//
+// describe('GameMap configuration options', () => {
+// 	test('walls should be configurable by color', () => {
+// 		const gameMap = new GameMap({ width: 10, height: 10 }, ColorName.RED, 1,
+// 			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
+// 		);
+//
+// 		gameMap.walls.forEach(wall => {
+// 			expect(wall.color).toBe(ColorName.RED);
+// 		});
+// 	});
+//
+// 	describe('gridline generation', () => {
+// 		let gameMap: GameMap;
+//
+// 		beforeEach(() => {
+// 			gameMap = new GameMap({ width: 10, height: 20 },
+// 				ColorName.RED,
+// 				1,
+// 				new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
+// 			);
+// 		});
+//
+// 		test('should initialize correct number of X gridlines', () => {
+// 			expect(gameMap.gridLinesX.length).toBe(10);
+// 		});
+//
+// 		test('should initialize correct number of Y gridlines', () => {
+// 			expect(gameMap.gridLinesY.length).toBe(20);
+// 		});
+// 	});
+// });
+//
+// describe('castRay method', () => {
+// 	let gameMap: GameMap;
+//
+// 	beforeEach(() => {
+// 		gameMap = new GameMap({ width: 10, height: 11 },
+// 			ColorName.GREEN,
+// 			1,
+// 			new MockPlayer({ x: 1, y: 1 }, 0, new MockTrail({ x: 1, y: 1 }))
+// 		);
+// 	});
+//
+// 	test('should return correct distance when ray hits boundary wall directly (0°)', () => {
+// 		const expectedDistance = 9;
+// 		gameMap.castRay(0, 11);
+// 		expect(gameMap.currentSlice.distance).toBeCloseTo(expectedDistance, 5);
+// 	});
+//
+// 	test('should return correct distance when ray hits boundary at 45°', () => {
+// 		const expectedDistance = Math.sqrt((10 - 1) ** 2 + (11 - 1) ** 2);
+// 		gameMap.castRay(Math.atan2(10, 9), 20);
+// 		expect(gameMap.currentSlice.distance).toBeCloseTo(expectedDistance, 5);
+// 	});
+//
+// 	test('should return max distance if ray hits nothing (looking away from all walls)', () => {
+// 		gameMap = new GameMap({ width: 32, height: 11 }, ColorName.GREEN, 1,
+// 			new MockPlayer({ x: 16, y: 5 }, 0, new MockTrail({ x: 16, y: 5 }))
+// 		);
+// 		gameMap.castRay(Math.PI, 15); // Facing negative x direction
+// 		expect(gameMap.currentSlice.distance).toEqual(15);
+// 		expect(gameMap.currentSlice.color).toEqual(ColorName.NONE);
+// 	});
+//
+//
+// 	test('should return same point for zero-length ray', () => {
+// 		gameMap.castRay(0, 0);
+// 		expect(gameMap.currentSlice.distance).toEqual(0);
+// 		expect(gameMap.currentSlice.intersection).toEqual(gameMap.playerPosition);
+// 	});
+//
+// 	test('should return correct intersection for vertical ray', () => {
+// 		gameMap.castRay(Math.PI / 2, 11); // Upward
+// 		expect(gameMap.currentSlice.intersection.x).toBeCloseTo(1, 5);
+// 		expect(gameMap.currentSlice.intersection.y).toBeGreaterThan(1);
+// 	});
+//
+// 	test('should handle grazing corner case gracefully', () => {
+// 		gameMap = new GameMap({
+// 			width: 32,
+// 			height: 11
+// 		},
+// 			ColorName.GREEN,
+// 			1,
+// 			new MockPlayer({ x: 0.001, y: 0.001 }, 0, new MockTrail({ x: 0.001, y: 0.001 }))
+// 		);
+// 		gameMap.castRay(Math.PI, 11);
+// 		expect(gameMap.currentSlice.distance).toBeGreaterThan(0);
+// 	});
+//
+// 	test('should not crash on near-parallel ray to a wall', () => {
+// 		const epsilon = 1e-8;
+// 		gameMap.castRay(epsilon, 20);
+// 		expect(gameMap.currentSlice.distance).toBeGreaterThan(0);
+// 	});
+// });
+// describe("Player tests", () => {
+// 	let player: PlayerInterface;
+// 	beforeEach(() => {
+// 		player = {
+// 			turnLeft: jest.fn(() => { }), turnRight: jest.fn(), move: jest.fn(() => { }), x: 1, y: 1, angle: 0, color: ColorName.GREEN,
+// 			trail: {
+// 				append: jest.fn(),
+// 				head: { x: 0, y: 0 },
+// 				tail: { x: 0, y: 0 },
+// 				color: ColorName.GREEN,
+// 			}
+// 		};
+// 	})
+// 	test("angle should be passed to player class", () => {
+// 		const gameMap = new GameMap({ width: 10, height: 20 }, ColorName.RED, 1, player);
+// 		gameMap.turnPlayer(Math.PI / 2)
+// 		expect(player.turnLeft).toHaveBeenLastCalledWith()
+// 	})
+// 	test("movePlayer should call player.move", () => {
+// 		const gameMap = new GameMap({ width: 10, height: 20 }, ColorName.RED, 1, player);
+// 		gameMap.movePlayer()
+// 		expect(player.move).toHaveBeenCalled()
+// 	})
+// })
+//
+// describe('intialization tests', () => {
+// 	let dimensions: Dimensions
+// 	let color: ColorName
+// 	let grid_size: number
+// 	let player: PlayerInterface
+// 	beforeEach(() => {
+// 		dimensions = { width: 100, height: 200 }
+// 		color = ColorName.RED
+// 		grid_size = 5
+// 		player = new MockPlayer({ x: -1, y: -1 }, 0, new MockTrail({ x: -1, y: -1 }))
+// 	})
+//
+// 	test('game map may not intialize with player position touching walls: left', () => {
+// 		player.x = 0
+// 		player.y = 5
+// 		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
+// 	})
+//
+// 	test('game map may not intialize with player position touching walls: top', () => {
+// 		player.x = 5
+// 		player.y = 0
+// 		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
+// 	})
+//
+// 	test('game map may not intialize with player position touching walls: right', () => {
+// 		player.x = 100
+// 		player.y = 5
+// 		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
+// 	})
+//
+// 	test('game map may not intialize with player position touching walls: bottom', () => {
+// 		player.x = 4
+// 		player.y = 200
+// 		expect(() => new GameMap(dimensions, color, grid_size, player)).toThrow()
+// 	})
+// })
+//
 
 
 describe('GameMap.castRay()', () => {
-	test("should not return a hit for the trail segment currently being drawn (trail head)", () => {
-		const position = { x: 5, y: 5 };
-		const directionAngle = Math.PI / 4; // right
-
-		const mockTrailHead: WallInterface = {
-			line: {
-				start: { x: 1, y: 5 },
-				end: { x: 5, y: 5 }
-			},
-			color: ColorName.RED// same as player's current position
-		};
-		const trail = new MockTrail(position);
-		trail.head = { x: 1, y: 5 }; // Set the head to the same position as the mockTrailHead
-
-		const player = new MockPlayer(position, directionAngle, trail);
-		const map = new GameMap({ width: 50, height: 50 }, ColorName.BLACK, 10, player);
-
-		map.castRay(directionAngle, 50);
-
-		expect(map.currentSlice.distance).not.toBe(0);
-	});
-
+	// test("should not return a hit for the trail segment currently being drawn (trail head)", () => {
+	// 	const position = { x: 5, y: 5 };
+	// 	const directionAngle = Math.PI / 4; // right
+	//
+	// 	const mockTrailHead: WallInterface = {
+	// 		line: {
+	// 			start: { x: 1, y: 5 },
+	// 			end: { x: 5, y: 5 }
+	// 		},
+	// 		color: ColorName.RED// same as player's current position
+	// 	};
+	// 	const trail = new MockTrail(position);
+	// 	trail.head = { x: 1, y: 5 }; // Set the head to the same position as the mockTrailHead
+	//
+	// 	const player = new MockPlayer(position, directionAngle, trail);
+	// 	const map = new GameMap({ width: 50, height: 50 }, ColorName.BLACK, 10, player);
+	//
+	// 	map.castRay(directionAngle, 50);
+	//
+	// 	expect(map.currentSlice.distance).not.toBe(0);
+	// });
+	//
 	test("should detect player's own wall if from a tenable viewpoint", () => {
 		const position = { x: 5, y: 4 };
 		const directionAngle = 0

--- a/app/raycaster/src/gamemap/map.test.tsx
+++ b/app/raycaster/src/gamemap/map.test.tsx
@@ -158,7 +158,6 @@ describe("Player tests", () => {
 	beforeEach(() => {
 		player = {
 			turnLeft: jest.fn(() => { }), turnRight: jest.fn(), move: jest.fn(() => { }), x: 1, y: 1, angle: 0, color: ColorName.GREEN,
-			temp: [],
 			trail: {
 				append: jest.fn(),
 				head: { x: 0, y: 0 },

--- a/app/raycaster/src/gamemap/map.test.tsx
+++ b/app/raycaster/src/gamemap/map.test.tsx
@@ -100,36 +100,36 @@ describe('castRay method', () => {
 
 	test('should return correct distance when ray hits boundary wall directly (0°)', () => {
 		const expectedDistance = 9;
-		const slice = gameMap.castRay(0, 11);
-		expect(slice.distance).toBeCloseTo(expectedDistance, 5);
+		gameMap.castRay(0, 11);
+		expect(gameMap.currentSlice.distance).toBeCloseTo(expectedDistance, 5);
 	});
 
 	test('should return correct distance when ray hits boundary at 45°', () => {
 		const expectedDistance = Math.sqrt((10 - 1) ** 2 + (11 - 1) ** 2);
-		const slice = gameMap.castRay(Math.atan2(10, 9), 20);
-		expect(slice.distance).toBeCloseTo(expectedDistance, 5);
+		gameMap.castRay(Math.atan2(10, 9), 20);
+		expect(gameMap.currentSlice.distance).toBeCloseTo(expectedDistance, 5);
 	});
 
 	test('should return max distance if ray hits nothing (looking away from all walls)', () => {
 		gameMap = new GameMap({ width: 32, height: 11 }, ColorName.GREEN, 1,
 			new MockPlayer({ x: 16, y: 5 }, 0, [])
 		);
-		const slice = gameMap.castRay(Math.PI, 15); // Facing negative x direction
-		expect(slice.distance).toEqual(15);
-		expect(slice.color).toEqual(ColorName.NONE);
+		gameMap.castRay(Math.PI, 15); // Facing negative x direction
+		expect(gameMap.currentSlice.distance).toEqual(15);
+		expect(gameMap.currentSlice.color).toEqual(ColorName.NONE);
 	});
 
 
 	test('should return same point for zero-length ray', () => {
-		const slice = gameMap.castRay(0, 0);
-		expect(slice.distance).toEqual(0);
-		expect(slice.intersection).toEqual(gameMap.playerPosition);
+		gameMap.castRay(0, 0);
+		expect(gameMap.currentSlice.distance).toEqual(0);
+		expect(gameMap.currentSlice.intersection).toEqual(gameMap.playerPosition);
 	});
 
 	test('should return correct intersection for vertical ray', () => {
-		const slice = gameMap.castRay(Math.PI / 2, 11); // Upward
-		expect(slice.intersection.x).toBeCloseTo(1, 5);
-		expect(slice.intersection.y).toBeGreaterThan(1);
+		gameMap.castRay(Math.PI / 2, 11); // Upward
+		expect(gameMap.currentSlice.intersection.x).toBeCloseTo(1, 5);
+		expect(gameMap.currentSlice.intersection.y).toBeGreaterThan(1);
 	});
 
 	test('should handle grazing corner case gracefully', () => {
@@ -141,14 +141,14 @@ describe('castRay method', () => {
 			1,
 			new MockPlayer({ x: 0.001, y: 0.001 }, 0, [])
 		);
-		const slice = gameMap.castRay(Math.PI, 11);
-		expect(slice.distance).toBeGreaterThan(0);
+		gameMap.castRay(Math.PI, 11);
+		expect(gameMap.currentSlice.distance).toBeGreaterThan(0);
 	});
 
 	test('should not crash on near-parallel ray to a wall', () => {
 		const epsilon = 1e-8;
-		const slice = gameMap.castRay(epsilon, 20);
-		expect(slice.distance).toBeGreaterThan(0);
+		gameMap.castRay(epsilon, 20);
+		expect(gameMap.currentSlice.distance).toBeGreaterThan(0);
 	});
 });
 describe("Player tests", () => {
@@ -226,9 +226,9 @@ describe('GameMap.castRay()', () => {
 		const player = new MockPlayer(position, directionAngle, [mockTrailHead]);
 		const map = new GameMap({ width: 50, height: 50 }, ColorName.BLACK, 10, player);
 
-		const slice = map.castRay(directionAngle, 50);
+		map.castRay(directionAngle, 50);
 
-		expect(slice.distance).not.toBe(0);
+		expect(map.currentSlice.distance).not.toBe(0);
 	});
 
 	test("should detect player's own wall if from a tenable viewpoint", () => {
@@ -259,8 +259,8 @@ describe('GameMap.castRay()', () => {
 		const player = new MockPlayer(position, directionAngle, mockTrail);
 		const map = new GameMap({ width: 50, height: 50 }, ColorName.BLACK, 10, player);
 
-		const slice = map.castRay(directionAngle, 50);
+		map.castRay(directionAngle, 50);
 
-		expect(slice.color).toBe(ColorName.RED);
+		expect(map.currentSlice.color).toBe(ColorName.RED);
 	})
 });

--- a/app/raycaster/src/gamemap/map.ts
+++ b/app/raycaster/src/gamemap/map.ts
@@ -1,4 +1,5 @@
 import { GameMapInterface, WallInterface } from './interface';
+import { TrailInterface } from '../trail/interface';
 import { Coordinates, LineSegment, Dimensions } from '../geometry/interfaces';
 import { ColorName } from '../color/color_name';
 import { PlayerInterface } from '../player/interface';
@@ -55,7 +56,7 @@ export class GameMap implements GameMapInterface {
 		];
 	}
 
-	get playerTrail(): WallInterface[] {
+	get playerTrail(): TrailInterface {
 		throw new Error("Player trail as Wall Interface isn't implemented");
 	}
 
@@ -111,16 +112,18 @@ export class GameMap implements GameMapInterface {
 			this.intersectionPool.release(hit);
 		}
 
-		for (let i = 0; i < this.playerTrail.length - 1; i++) {
-			const wall = this.playerTrail[i].line;
-			const hit = this.rayIntersectsWall(this.rayOrigin, rayDirection, wall);
+		let cur = this.playerTrail.head;
+		while (cur && cur.next) {
+			//todo: remove this implcit allocation in the assignment
+			const hit = this.rayIntersectsWall(this.rayOrigin, rayDirection, { start: cur, end: cur.next });
 			if (hit.isValid && hit.distance < closest.distance) {
+				closest.distance = hit.distance;
 				closest.x = hit.x;
 				closest.y = hit.y;
-				closest.distance = hit.distance;
-				color = this.player.color;
+				color = this.playerTrail.color;
 			}
 			this.intersectionPool.release(hit);
+			cur = cur.next;
 		}
 
 		const rayEnd = this.getRayEnd(rayDirection, closest.distance);

--- a/app/raycaster/src/gamemap/map.ts
+++ b/app/raycaster/src/gamemap/map.ts
@@ -23,7 +23,7 @@ export class GameMap implements GameMapInterface {
 	gridLinesX: LineSegment[] = [];
 	gridLinesY: LineSegment[] = [];
 	private gridLines: LineSegment[];
-	private intersectionPool: ObjectPool<Intersection> = new ObjectPool<Intersection>(1000, nullIntersection);
+	private intersectionPool: ObjectPool<Intersection> = new ObjectPool<Intersection>(32000, nullIntersection);
 	private rayPoint: Coordinates = { x: 0, y: 0 };
 	private bMath = BMath.getInstance();
 	private _currentSlice: Slice = { distance: 0, color: ColorName.NONE, gridHits: [], intersection: { x: 0, y: 0 } };
@@ -106,9 +106,9 @@ export class GameMap implements GameMapInterface {
 				closest.distance = hit.distance;
 				closest.x = hit.x;
 				closest.y = hit.y;
-				this.intersectionPool.release(hit);
 				color = wall.color;
 			}
+			this.intersectionPool.release(hit);
 		}
 
 		for (let i = 0; i < this.playerTrail.length - 1; i++) {
@@ -118,9 +118,9 @@ export class GameMap implements GameMapInterface {
 				closest.x = hit.x;
 				closest.y = hit.y;
 				closest.distance = hit.distance;
-				this.intersectionPool.release(hit);
 				color = this.player.color;
 			}
+			this.intersectionPool.release(hit);
 		}
 
 		const rayEnd = this.getRayEnd(rayDirection, closest.distance);
@@ -141,6 +141,7 @@ export class GameMap implements GameMapInterface {
 			if (hit.isValid && hit.distance < maxDistance) {
 				gridHits.push(hit.distance);
 			}
+			this.intersectionPool.release(hit);
 		}
 		return gridHits;
 	}

--- a/app/raycaster/src/gamemap/map.ts
+++ b/app/raycaster/src/gamemap/map.ts
@@ -113,6 +113,7 @@ export class GameMap implements GameMapInterface {
 		}
 
 		let cur = this.playerTrail.head;
+		console.log({ cur })
 		while (cur && cur.next) {
 			//todo: remove this implcit allocation in the assignment
 			const hit = this.rayIntersectsWall(this.rayOrigin, rayDirection, { start: cur, end: cur.next });

--- a/app/raycaster/src/gamemap/map.ts
+++ b/app/raycaster/src/gamemap/map.ts
@@ -56,7 +56,7 @@ export class GameMap implements GameMapInterface {
 	}
 
 	get playerTrail(): WallInterface[] {
-		return this.player.trail
+		return this.player.temp
 	}
 
 	get playerPosition(): Coordinates {

--- a/app/raycaster/src/gamemap/map.ts
+++ b/app/raycaster/src/gamemap/map.ts
@@ -26,6 +26,8 @@ export class GameMap implements GameMapInterface {
 	private intersectionPool: ObjectPool<Intersection> = new ObjectPool<Intersection>(1000, nullIntersection);
 	private rayPoint: Coordinates = { x: 0, y: 0 };
 	private bMath = BMath.getInstance();
+	private _currentSlice: Slice = { distance: 0, color: ColorName.NONE, gridHits: [], intersection: { x: 0, y: 0 } };
+
 	constructor(
 		size: Dimensions,
 		boundaryColor: ColorName = ColorName.BLACK,
@@ -62,13 +64,12 @@ export class GameMap implements GameMapInterface {
 	}
 
 	get currentSlice(): Slice {
-		throw new Error("currentSlice is not yet implemented in GameMap");
+		return this._currentSlice;
 	}
 
 	get playerAngle(): number {
 		return this.player.angle;
 	}
-
 	public resetIntersections(): void {
 		this.intersectionPool.clear();
 	}
@@ -89,7 +90,7 @@ export class GameMap implements GameMapInterface {
 		}
 	}
 
-	castRay(angle: number, maximumAllowableDistance: number): Slice {
+	castRay(angle: number, maximumAllowableDistance: number): void {
 		const rayDirection = this.rayDirecton(angle);
 		let closest = this.deafaultIntersection(maximumAllowableDistance);
 		let color = ColorName.NONE;
@@ -115,13 +116,11 @@ export class GameMap implements GameMapInterface {
 
 		const rayEnd = this.getRayEnd(rayDirection, closest.distance);
 		const gridHits = this.getGridHits(rayOrigin, rayDirection, closest.distance);
-		// this is returning an object: might need to refactor so it exposes an object
-		return {
-			distance: closest.distance,
-			color,
-			gridHits,
-			intersection: rayEnd
-		};
+
+		this._currentSlice.distance = closest.distance;
+		this._currentSlice.color = color;
+		this._currentSlice.gridHits = gridHits;
+		this._currentSlice.intersection = rayEnd;
 	}
 
 	private getGridHits(origin: Coordinates, rayDirection: Coordinates, maxDistance: number): number[] {

--- a/app/raycaster/src/gamemap/map.ts
+++ b/app/raycaster/src/gamemap/map.ts
@@ -57,7 +57,7 @@ export class GameMap implements GameMapInterface {
 	}
 
 	get playerTrail(): TrailInterface {
-		throw new Error("Player trail as Wall Interface isn't implemented");
+		return this.player.trail;
 	}
 
 	get playerPosition(): Coordinates {

--- a/app/raycaster/src/gamemap/map.ts
+++ b/app/raycaster/src/gamemap/map.ts
@@ -28,6 +28,7 @@ export class GameMap implements GameMapInterface {
 	private bMath = BMath.getInstance();
 	private _currentSlice: Slice = { distance: 0, color: ColorName.NONE, gridHits: [], intersection: { x: 0, y: 0 } };
 	private rayOrigin: Coordinates = { x: 0, y: 0 };
+
 	constructor(
 		size: Dimensions,
 		boundaryColor: ColorName = ColorName.BLACK,
@@ -60,6 +61,7 @@ export class GameMap implements GameMapInterface {
 
 	get playerPosition(): Coordinates {
 		const { x, y } = this.player;
+		//ton of object creation here -- will need to change this later
 		return { x, y };
 	}
 
@@ -104,8 +106,8 @@ export class GameMap implements GameMapInterface {
 				closest.distance = hit.distance;
 				closest.x = hit.x;
 				closest.y = hit.y;
+				this.intersectionPool.release(hit);
 				color = wall.color;
-				//todo: allocate and remove "hit"
 			}
 		}
 
@@ -116,9 +118,8 @@ export class GameMap implements GameMapInterface {
 				closest.x = hit.x;
 				closest.y = hit.y;
 				closest.distance = hit.distance;
+				this.intersectionPool.release(hit);
 				color = this.player.color;
-
-				//TODO: allocate and remove "hit"
 			}
 		}
 
@@ -188,7 +189,8 @@ export class GameMap implements GameMapInterface {
 		this.rayPoint.y = rayOrigin.y + direction.y;
 		const rayPoint = this.rayPoint;
 		const determinant = this.calculateDeterminant(wall.start, wall.end, rayOrigin, rayPoint);
-		const result = { isValid: false, x: -1, y: -1, distance: Infinity };
+		const result = this.intersectionPool.acquire();
+		result.isValid = false;
 
 		if (this.isParallel(determinant)) {
 			return result;

--- a/app/raycaster/src/gamemap/map.ts
+++ b/app/raycaster/src/gamemap/map.ts
@@ -113,7 +113,6 @@ export class GameMap implements GameMapInterface {
 		}
 
 		let cur = this.playerTrail.head;
-		console.log({ cur })
 		while (cur && cur.next) {
 			//todo: remove this implcit allocation in the assignment
 			const hit = this.rayIntersectsWall(this.rayOrigin, rayDirection, { start: cur, end: cur.next });

--- a/app/raycaster/src/gamemap/map.ts
+++ b/app/raycaster/src/gamemap/map.ts
@@ -56,7 +56,7 @@ export class GameMap implements GameMapInterface {
 	}
 
 	get playerTrail(): WallInterface[] {
-		return this.player.temp
+		throw new Error("Player trail as Wall Interface isn't implemented");
 	}
 
 	get playerPosition(): Coordinates {

--- a/app/raycaster/src/objectPool/objectPool.ts
+++ b/app/raycaster/src/objectPool/objectPool.ts
@@ -3,7 +3,11 @@ export class ObjectPool<T> {
 	private top: number = 0;
 	private pool: T[];
 
-	constructor(size: number = 1500, private factory: () => T) {
+	constructor(
+		size: number = 1500,
+		private factory: () => T,
+		private dynamicAllocation: boolean = false
+	) {
 		this.pool = new Array(size);
 		for (let i = 0; i < size; i++) {
 			this.pool[i] = this.factory();
@@ -13,10 +17,18 @@ export class ObjectPool<T> {
 
 	acquire(): T {
 		if (this.top == 0) {
-			this.reallocate();
+			if (this.dynamicAllocation) {
+				this.reallocate();
+			} else {
+				throw new Error('Object pool underflow, you may not acquire more objects than the pool size');
+			}
 		}
 		this.top--;
 		return this.pool[this.top];
+	}
+
+	clear(): void {
+		this.top = this.pool.length;
 	}
 
 	release(object: T): void {

--- a/app/raycaster/src/player/interface.ts
+++ b/app/raycaster/src/player/interface.ts
@@ -1,4 +1,5 @@
 import { ColorName } from '../color/color_name';
+import { TrailInterface } from '../trail/interface';
 import { WallInterface } from '../gamemap/interface';
 
 export interface PlayerInterface {
@@ -7,7 +8,8 @@ export interface PlayerInterface {
 	x: number;
 	y: number;
 	move: () => void;
-	trail: WallInterface[];
+	trail: TrailInterface;
 	angle: number;
 	color: ColorName;
+	temp: WallInterface[];
 }

--- a/app/raycaster/src/player/interface.ts
+++ b/app/raycaster/src/player/interface.ts
@@ -1,6 +1,5 @@
 import { ColorName } from '../color/color_name';
 import { TrailInterface } from '../trail/interface';
-import { WallInterface } from '../gamemap/interface';
 
 export interface PlayerInterface {
 	turnLeft: () => void;
@@ -11,5 +10,4 @@ export interface PlayerInterface {
 	trail: TrailInterface;
 	angle: number;
 	color: ColorName;
-	temp: WallInterface[];
 }

--- a/app/raycaster/src/player/player.test.tsx
+++ b/app/raycaster/src/player/player.test.tsx
@@ -12,15 +12,6 @@ function areCoordsEqual(a: Coordinates, b: Coordinates): boolean {
 	return a.x === b.x && a.y === b.y;
 }
 
-function isTrailContinuous(trail: WallInterface[]): boolean {
-	for (let i = 0; i < trail.length - 1; i++) {
-		if (!areCoordsEqual(trail[i].line.end, trail[i + 1].line.start)) {
-			return false;
-		}
-	}
-	return true;
-}
-
 class MockCamera implements CameraInterface {
 	isRotating: boolean = false;
 	adjust(): void { }
@@ -102,25 +93,6 @@ describe('Player.move - trail continuity', () => {
 
 		expect(player.trail.head).toEqual(expect.objectContaining({ x: 10, y: 0 }));
 		expect(player.trail.tail).toEqual(expect.objectContaining({ x: 0, y: 0 }));
-	});
-
-	test('creates a continuous trail when turning right', () => {
-		const speed = 1;
-		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera(), new MockTrail());
-
-		player.move();
-		player.turnRight();
-
-		for (let i = 0; i < 4; i++) {
-			player.move();
-		}
-
-		for (let i = 0; i < 5; i++) {
-			player.move();
-		}
-
-		const trail = player.temp;
-		expect(isTrailContinuous(trail)).toBe(true);
 	});
 
 	test('Adds points to the trail at turns', () => {

--- a/app/raycaster/src/player/player.test.tsx
+++ b/app/raycaster/src/player/player.test.tsx
@@ -5,6 +5,7 @@ import { WallInterface } from '../gamemap/interface';
 import { CameraInterface } from '../camera/interface';
 import { Directions } from '../controls/directions';
 import { ColorName } from '../color/color_name';
+import { TrailInterface } from '../trail/interface';
 import { NINETY_DEGREES, TWO_HUNDRED_SEVENTY_DEGREES } from '../geometry/constants';
 
 function areCoordsEqual(a: Coordinates, b: Coordinates): boolean {
@@ -26,13 +27,18 @@ class MockCamera implements CameraInterface {
 	beginTurnExecution(d: Directions): void { }
 	angle: number = 0;
 }
-
+class MockTrail implements TrailInterface {
+	head: { x: number, y: number } = { x: 0, y: 0 };
+	tail: { x: number, y: number } = { x: 0, y: 0 };
+	color: ColorName = ColorName.RED;
+	append(x: number, y: number): void { }
+}
 describe('Player.move())', () => {
 	test('given  a player is at coordinates 5, 5 with an angle of 0 and a speed of 5, when move is called, then the resulting coordinates are 10,5', () => {
 		const speed = 5;
 		const camera = new MockCamera();
 		camera.angle = 0;
-		const player = new Player({ x: 5, y: 5 }, speed, ColorName.RED, camera);
+		const player = new Player({ x: 5, y: 5 }, speed, ColorName.RED, camera, new MockTrail());
 		player.move();
 		expect(player.x).toBe(10);
 		expect(player.y).toBe(5);
@@ -41,7 +47,7 @@ describe('Player.move())', () => {
 		const speed = 7;
 		const camera = new MockCamera();
 		camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
-		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera);
+		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera, new MockTrail());
 		player.move();
 		expect(player.x).toBe(9);
 		expect(player.y).toBe(3);
@@ -50,7 +56,7 @@ describe('Player.move())', () => {
 		const speed = 7;
 		const camera = new MockCamera();
 		camera.angle = Math.PI / 2;
-		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera);
+		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera, new MockTrail());
 		player.move();
 		expect(player.x).toBe(9);
 		expect(player.y).toBe(17);
@@ -61,7 +67,7 @@ describe('Player. turns', () => {
 		const speed = 2
 		const turnDistance = 11
 		const camera = new MockCamera();
-		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera)
+		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera, new MockTrail());
 
 		player.turnLeft()
 
@@ -75,7 +81,7 @@ describe('Player. turns', () => {
 		const speed = 2
 		const turnDistance = 40
 		const camera = new MockCamera();
-		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera);
+		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera, new MockTrail());
 		player.turnRight()
 		for (let i = 0; i < turnDistance; i += speed) {
 			camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
@@ -88,7 +94,7 @@ describe('Player. turns', () => {
 describe('Player.move - trail continuity', () => {
 	test('creates a continuous trail when moving straight', () => {
 		const speed = 1;
-		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera());
+		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera(), new MockTrail());
 
 		for (let i = 0; i < 10; i++) {
 			player.move();
@@ -102,7 +108,7 @@ describe('Player.move - trail continuity', () => {
 
 	test('creates a continuous trail when turning right', () => {
 		const speed = 1;
-		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera());
+		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera(), new MockTrail());
 
 		player.move();
 		player.turnRight();
@@ -124,7 +130,7 @@ describe('Player.move - trail continuity', () => {
 		const speed = 1;
 		const camera = new MockCamera();
 		camera.isRotating = false;
-		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, camera);
+		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, camera, new MockTrail());
 
 		player.move();
 		player.turnRight();

--- a/app/raycaster/src/player/player.test.tsx
+++ b/app/raycaster/src/player/player.test.tsx
@@ -137,15 +137,13 @@ describe('Player.move - trail continuity', () => {
 		camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
 		player.move();
 		expect(trail.append).toHaveBeenCalledWith(0, 0);
+		for (let i = 0; i < 4; i++) {
+			player.move();
+		}
+		player.turnLeft();
+		camera.angle = 0;
 		player.move();
-		expect(trail.append).not.toHaveBeenCalled();
-		// for (let i = 0; i < 4; i++) {
-		// 	player.move();
-		// }
-		// player.turnLeft();
-		// camera.angle = 0;
-		// player.move();
-		// expect(trail.append).toHaveBeenCalledWith(0, -4);
+		expect(trail.append).toHaveBeenCalledWith(0, -5);
 	});
 });
 

--- a/app/raycaster/src/player/player.test.tsx
+++ b/app/raycaster/src/player/player.test.tsx
@@ -100,7 +100,7 @@ describe('Player.move - trail continuity', () => {
 			player.move();
 		}
 
-		const trail = player.trail;
+		const trail = player.temp;
 		expect(trail.length).toBe(1);
 		expect(trail[0].line.start).toEqual({ x: 0, y: 0 });
 		expect(trail[0].line.end).toEqual({ x: 10, y: 0 });
@@ -121,7 +121,7 @@ describe('Player.move - trail continuity', () => {
 			player.move();
 		}
 
-		const trail = player.trail;
+		const trail = player.temp;
 		expect(trail.length).toBeGreaterThan(1);
 		expect(isTrailContinuous(trail)).toBe(true);
 	});
@@ -140,7 +140,7 @@ describe('Player.move - trail continuity', () => {
 		for (let i = 0; i < 4; i++) player.move();
 		for (let i = 0; i < 3; i++) player.move();
 
-		const trail = player.trail;
+		const trail = player.temp;
 		expect(trail.length).toBeGreaterThan(2);
 		expect(isTrailContinuous(trail)).toBe(true);
 	});

--- a/app/raycaster/src/player/player.test.tsx
+++ b/app/raycaster/src/player/player.test.tsx
@@ -33,116 +33,117 @@ class MockTrail implements TrailInterface {
 	color: ColorName = ColorName.RED;
 	append(x: number, y: number): void { }
 }
-describe('Player.move())', () => {
-	test('given  a player is at coordinates 5, 5 with an angle of 0 and a speed of 5, when move is called, then the resulting coordinates are 10,5', () => {
-		const speed = 5;
-		const camera = new MockCamera();
-		camera.angle = 0;
-		const player = new Player({ x: 5, y: 5 }, speed, ColorName.RED, camera, new MockTrail());
-		player.move();
-		expect(player.x).toBe(10);
-		expect(player.y).toBe(5);
-	})
-	test('given  a player is at coordinates 9, 10 with an angle of 3pi/2 and a speed of 7, when move is called, then the resulting coordinates are 9, 3', () => {
-		const speed = 7;
-		const camera = new MockCamera();
-		camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
-		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera, new MockTrail());
-		player.move();
-		expect(player.x).toBe(9);
-		expect(player.y).toBe(3);
-	})
-	test('given  a player is at coordinates 9, 10 with an angle of pi/2 and a speed of 7, when move is called, then the resulting coordinates are 9, 24', () => {
-		const speed = 7;
-		const camera = new MockCamera();
-		camera.angle = Math.PI / 2;
-		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera, new MockTrail());
-		player.move();
-		expect(player.x).toBe(9);
-		expect(player.y).toBe(17);
-	})
-})
-describe('Player. turns', () => {
-	test('given a player has a 0 degree heading, when the player.rotate is called with 90 degress is moved <turn interval> time, then the players angle is reset to 90 degress.', () => {
-		const speed = 2
-		const turnDistance = 11
-		const camera = new MockCamera();
-		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera, new MockTrail());
-
-		player.turnLeft()
-
-		for (let i = 0; i < turnDistance; i += speed) {
-			camera.angle = NINETY_DEGREES;
-			player.move()
-		}
-		expect(player.angle).toBe(NINETY_DEGREES);
-	})
-	test('rotating a player by -90 degrees should change the angle from 0 to 3*Math.PI / 2', () => {
-		const speed = 2
-		const turnDistance = 40
-		const camera = new MockCamera();
-		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera, new MockTrail());
-		player.turnRight()
-		for (let i = 0; i < turnDistance; i += speed) {
-			camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
-			player.move()
-		}
-		expect(player.angle).toEqual(TWO_HUNDRED_SEVENTY_DEGREES);
-	})
-})
-
+//describe('Player.move())', () => {
+// 	test('given  a player is at coordinates 5, 5 with an angle of 0 and a speed of 5, when move is called, then the resulting coordinates are 10,5', () => {
+// 		const speed = 5;
+// 		const camera = new MockCamera();
+// 		camera.angle = 0;
+// 		const player = new Player({ x: 5, y: 5 }, speed, ColorName.RED, camera, new MockTrail());
+// 		player.move();
+// 		expect(player.x).toBe(10);
+// 		expect(player.y).toBe(5);
+// 	})
+// 	test('given  a player is at coordinates 9, 10 with an angle of 3pi/2 and a speed of 7, when move is called, then the resulting coordinates are 9, 3', () => {
+// 		const speed = 7;
+// 		const camera = new MockCamera();
+// 		camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
+// 		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera, new MockTrail());
+// 		player.move();
+// 		expect(player.x).toBe(9);
+// 		expect(player.y).toBe(3);
+// 	})
+// 	test('given  a player is at coordinates 9, 10 with an angle of pi/2 and a speed of 7, when move is called, then the resulting coordinates are 9, 24', () => {
+// 		const speed = 7;
+// 		const camera = new MockCamera();
+// 		camera.angle = Math.PI / 2;
+// 		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera, new MockTrail());
+// 		player.move();
+// 		expect(player.x).toBe(9);
+// 		expect(player.y).toBe(17);
+// 	})
+// })
+// describe('Player. turns', () => {
+// 	test('given a player has a 0 degree heading, when the player.rotate is called with 90 degress is moved <turn interval> time, then the players angle is reset to 90 degress.', () => {
+// 		const speed = 2
+// 		const turnDistance = 11
+// 		const camera = new MockCamera();
+// 		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera, new MockTrail());
+//
+// 		player.turnLeft()
+//
+// 		for (let i = 0; i < turnDistance; i += speed) {
+// 			camera.angle = NINETY_DEGREES;
+// 			player.move()
+// 		}
+// 		expect(player.angle).toBe(NINETY_DEGREES);
+// 	})
+// 	test('rotating a player by -90 degrees should change the angle from 0 to 3*Math.PI / 2', () => {
+// 		const speed = 2
+// 		const turnDistance = 40
+// 		const camera = new MockCamera();
+// 		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera, new MockTrail());
+// 		player.turnRight()
+// 		for (let i = 0; i < turnDistance; i += speed) {
+// 			camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
+// 			player.move()
+// 		}
+// 		expect(player.angle).toEqual(TWO_HUNDRED_SEVENTY_DEGREES);
+// 	})
+// })
+//
 describe('Player.move - trail continuity', () => {
-	test('creates a continuous trail when moving straight', () => {
-		const speed = 1;
-		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera(), new MockTrail());
-
-		for (let i = 0; i < 10; i++) {
-			player.move();
-		}
-
-		const trail = player.temp;
-		expect(trail.length).toBe(1);
-		expect(trail[0].line.start).toEqual({ x: 0, y: 0 });
-		expect(trail[0].line.end).toEqual({ x: 10, y: 0 });
-	});
-
-	test('creates a continuous trail when turning right', () => {
-		const speed = 1;
-		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera(), new MockTrail());
-
-		player.move();
-		player.turnRight();
-
-		for (let i = 0; i < 4; i++) {
-			player.move();
-		}
-
-		for (let i = 0; i < 5; i++) {
-			player.move();
-		}
-
-		const trail = player.temp;
-		expect(trail.length).toBeGreaterThan(1);
-		expect(isTrailContinuous(trail)).toBe(true);
-	});
-
-	test('creates a continuous trail with multiple turns', () => {
+	// test('creates a continuous trail when moving straight', () => {
+	// 	const speed = 1;
+	// 	const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera(), new MockTrail());
+	//
+	// 	for (let i = 0; i < 10; i++) {
+	// 		player.move();
+	// 	}
+	//
+	// 	const trail = player.temp;
+	// 	expect(trail.length).toBe(1);
+	// 	expect(trail[0].line.start).toEqual({ x: 0, y: 0 });
+	// 	expect(trail[0].line.end).toEqual({ x: 10, y: 0 });
+	// });
+	//
+	// test('creates a continuous trail when turning right', () => {
+	// 	const speed = 1;
+	// 	const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera(), new MockTrail());
+	//
+	// 	player.move();
+	// 	player.turnRight();
+	//
+	// 	for (let i = 0; i < 4; i++) {
+	// 		player.move();
+	// 	}
+	//
+	// 	for (let i = 0; i < 5; i++) {
+	// 		player.move();
+	// 	}
+	//
+	// 	const trail = player.temp;
+	// 	expect(isTrailContinuous(trail)).toBe(true);
+	// });
+	//
+	test('Adds points to the trail at turns', () => {
 		const speed = 1;
 		const camera = new MockCamera();
 		camera.isRotating = false;
-		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, camera, new MockTrail());
+		const trail = new MockTrail();
+		jest.spyOn(trail, 'append').mockImplementation(() => { });
+		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, camera, trail);
 
-		player.move();
 		player.turnRight();
-		for (let i = 0; i < 4; i++) player.move();
-		for (let i = 0; i < 3; i++) player.move();
-		player.turnLeft();
-		for (let i = 0; i < 4; i++) player.move();
-		for (let i = 0; i < 3; i++) player.move();
-
-		const trail = player.temp;
-		expect(trail.length).toBeGreaterThan(2);
-		expect(isTrailContinuous(trail)).toBe(true);
+		camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
+		player.move();
+		expect(trail.append).toHaveBeenCalledWith(0, 0);
+		// for (let i = 0; i < 4; i++) {
+		// 	player.move();
+		// }
+		// player.turnLeft();
+		// camera.angle = 0;
+		// player.move();
+		// expect(trail.append).toHaveBeenCalledWith(0, -4);
 	});
 });
 

--- a/app/raycaster/src/player/player.test.tsx
+++ b/app/raycaster/src/player/player.test.tsx
@@ -137,6 +137,8 @@ describe('Player.move - trail continuity', () => {
 		camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
 		player.move();
 		expect(trail.append).toHaveBeenCalledWith(0, 0);
+		player.move();
+		expect(trail.append).not.toHaveBeenCalled();
 		// for (let i = 0; i < 4; i++) {
 		// 	player.move();
 		// }

--- a/app/raycaster/src/player/player.test.tsx
+++ b/app/raycaster/src/player/player.test.tsx
@@ -33,98 +33,98 @@ class MockTrail implements TrailInterface {
 	color: ColorName = ColorName.RED;
 	append(x: number, y: number): void { }
 }
-//describe('Player.move())', () => {
-// 	test('given  a player is at coordinates 5, 5 with an angle of 0 and a speed of 5, when move is called, then the resulting coordinates are 10,5', () => {
-// 		const speed = 5;
-// 		const camera = new MockCamera();
-// 		camera.angle = 0;
-// 		const player = new Player({ x: 5, y: 5 }, speed, ColorName.RED, camera, new MockTrail());
-// 		player.move();
-// 		expect(player.x).toBe(10);
-// 		expect(player.y).toBe(5);
-// 	})
-// 	test('given  a player is at coordinates 9, 10 with an angle of 3pi/2 and a speed of 7, when move is called, then the resulting coordinates are 9, 3', () => {
-// 		const speed = 7;
-// 		const camera = new MockCamera();
-// 		camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
-// 		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera, new MockTrail());
-// 		player.move();
-// 		expect(player.x).toBe(9);
-// 		expect(player.y).toBe(3);
-// 	})
-// 	test('given  a player is at coordinates 9, 10 with an angle of pi/2 and a speed of 7, when move is called, then the resulting coordinates are 9, 24', () => {
-// 		const speed = 7;
-// 		const camera = new MockCamera();
-// 		camera.angle = Math.PI / 2;
-// 		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera, new MockTrail());
-// 		player.move();
-// 		expect(player.x).toBe(9);
-// 		expect(player.y).toBe(17);
-// 	})
-// })
-// describe('Player. turns', () => {
-// 	test('given a player has a 0 degree heading, when the player.rotate is called with 90 degress is moved <turn interval> time, then the players angle is reset to 90 degress.', () => {
-// 		const speed = 2
-// 		const turnDistance = 11
-// 		const camera = new MockCamera();
-// 		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera, new MockTrail());
-//
-// 		player.turnLeft()
-//
-// 		for (let i = 0; i < turnDistance; i += speed) {
-// 			camera.angle = NINETY_DEGREES;
-// 			player.move()
-// 		}
-// 		expect(player.angle).toBe(NINETY_DEGREES);
-// 	})
-// 	test('rotating a player by -90 degrees should change the angle from 0 to 3*Math.PI / 2', () => {
-// 		const speed = 2
-// 		const turnDistance = 40
-// 		const camera = new MockCamera();
-// 		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera, new MockTrail());
-// 		player.turnRight()
-// 		for (let i = 0; i < turnDistance; i += speed) {
-// 			camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
-// 			player.move()
-// 		}
-// 		expect(player.angle).toEqual(TWO_HUNDRED_SEVENTY_DEGREES);
-// 	})
-// })
-//
+describe('Player.move())', () => {
+	test('given  a player is at coordinates 5, 5 with an angle of 0 and a speed of 5, when move is called, then the resulting coordinates are 10,5', () => {
+		const speed = 5;
+		const camera = new MockCamera();
+		camera.angle = 0;
+		const player = new Player({ x: 5, y: 5 }, speed, ColorName.RED, camera, new MockTrail());
+		player.move();
+		expect(player.x).toBe(10);
+		expect(player.y).toBe(5);
+	})
+	test('given  a player is at coordinates 9, 10 with an angle of 3pi/2 and a speed of 7, when move is called, then the resulting coordinates are 9, 3', () => {
+		const speed = 7;
+		const camera = new MockCamera();
+		camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
+		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera, new MockTrail());
+		player.move();
+		expect(player.x).toBe(9);
+		expect(player.y).toBe(3);
+	})
+	test('given  a player is at coordinates 9, 10 with an angle of pi/2 and a speed of 7, when move is called, then the resulting coordinates are 9, 24', () => {
+		const speed = 7;
+		const camera = new MockCamera();
+		camera.angle = Math.PI / 2;
+		const player = new Player({ x: 9, y: 10 }, speed, ColorName.RED, camera, new MockTrail());
+		player.move();
+		expect(player.x).toBe(9);
+		expect(player.y).toBe(17);
+	})
+})
+describe('Player. turns', () => {
+	test('given a player has a 0 degree heading, when the player.rotate is called with 90 degress is moved <turn interval> time, then the players angle is reset to 90 degress.', () => {
+		const speed = 2
+		const turnDistance = 11
+		const camera = new MockCamera();
+		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera, new MockTrail());
+
+		player.turnLeft()
+
+		for (let i = 0; i < turnDistance; i += speed) {
+			camera.angle = NINETY_DEGREES;
+			player.move()
+		}
+		expect(player.angle).toBe(NINETY_DEGREES);
+	})
+	test('rotating a player by -90 degrees should change the angle from 0 to 3*Math.PI / 2', () => {
+		const speed = 2
+		const turnDistance = 40
+		const camera = new MockCamera();
+		const player = new Player({ x: 1, y: 1 }, speed, ColorName.RED, camera, new MockTrail());
+		player.turnRight()
+		for (let i = 0; i < turnDistance; i += speed) {
+			camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
+			player.move()
+		}
+		expect(player.angle).toEqual(TWO_HUNDRED_SEVENTY_DEGREES);
+	})
+})
+
 describe('Player.move - trail continuity', () => {
-	// test('creates a continuous trail when moving straight', () => {
-	// 	const speed = 1;
-	// 	const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera(), new MockTrail());
-	//
-	// 	for (let i = 0; i < 10; i++) {
-	// 		player.move();
-	// 	}
-	//
-	// 	const trail = player.temp;
-	// 	expect(trail.length).toBe(1);
-	// 	expect(trail[0].line.start).toEqual({ x: 0, y: 0 });
-	// 	expect(trail[0].line.end).toEqual({ x: 10, y: 0 });
-	// });
-	//
-	// test('creates a continuous trail when turning right', () => {
-	// 	const speed = 1;
-	// 	const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera(), new MockTrail());
-	//
-	// 	player.move();
-	// 	player.turnRight();
-	//
-	// 	for (let i = 0; i < 4; i++) {
-	// 		player.move();
-	// 	}
-	//
-	// 	for (let i = 0; i < 5; i++) {
-	// 		player.move();
-	// 	}
-	//
-	// 	const trail = player.temp;
-	// 	expect(isTrailContinuous(trail)).toBe(true);
-	// });
-	//
+	test('creates a continuous trail when moving straight', () => {
+		const speed = 1;
+		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera(), new MockTrail());
+
+		for (let i = 0; i < 10; i++) {
+			player.move();
+		}
+
+		const trail = player.temp;
+		expect(trail.length).toBe(1);
+		expect(trail[0].line.start).toEqual({ x: 0, y: 0 });
+		expect(trail[0].line.end).toEqual({ x: 10, y: 0 });
+	});
+
+	test('creates a continuous trail when turning right', () => {
+		const speed = 1;
+		const player = new Player({ x: 0, y: 0 }, speed, ColorName.RED, new MockCamera(), new MockTrail());
+
+		player.move();
+		player.turnRight();
+
+		for (let i = 0; i < 4; i++) {
+			player.move();
+		}
+
+		for (let i = 0; i < 5; i++) {
+			player.move();
+		}
+
+		const trail = player.temp;
+		expect(isTrailContinuous(trail)).toBe(true);
+	});
+
 	test('Adds points to the trail at turns', () => {
 		const speed = 1;
 		const camera = new MockCamera();
@@ -136,14 +136,16 @@ describe('Player.move - trail continuity', () => {
 		player.turnRight();
 		camera.angle = TWO_HUNDRED_SEVENTY_DEGREES;
 		player.move();
+
 		expect(trail.append).toHaveBeenCalledWith(0, 0);
+
 		for (let i = 0; i < 4; i++) {
 			player.move();
 		}
 		player.turnLeft();
 		camera.angle = 0;
 		player.move();
+
 		expect(trail.append).toHaveBeenCalledWith(0, -5);
 	});
 });
-

--- a/app/raycaster/src/player/player.test.tsx
+++ b/app/raycaster/src/player/player.test.tsx
@@ -100,10 +100,8 @@ describe('Player.move - trail continuity', () => {
 			player.move();
 		}
 
-		const trail = player.temp;
-		expect(trail.length).toBe(1);
-		expect(trail[0].line.start).toEqual({ x: 0, y: 0 });
-		expect(trail[0].line.end).toEqual({ x: 10, y: 0 });
+		expect(player.trail.head).toEqual(expect.objectContaining({ x: 10, y: 0 }));
+		expect(player.trail.tail).toEqual(expect.objectContaining({ x: 0, y: 0 }));
 	});
 
 	test('creates a continuous trail when turning right', () => {

--- a/app/raycaster/src/player/player.ts
+++ b/app/raycaster/src/player/player.ts
@@ -85,9 +85,7 @@ class Player implements PlayerInterface {
 	}
 
 	private growTrail(): void {
-		this.trail.head.x = this.x;
-		this.trail.head.y = this.y;
-		//this._temp[this._temp.length - 1].line.end = { x: this.x, y: this.y };
+		Object.assign(this.trail.head, { x: this.x, y: this.y });
 	}
 
 	private moveAlongHeading(): void {

--- a/app/raycaster/src/player/player.ts
+++ b/app/raycaster/src/player/player.ts
@@ -85,7 +85,9 @@ class Player implements PlayerInterface {
 	}
 
 	private growTrail(): void {
-		this._temp[this._temp.length - 1].line.end = { x: this.x, y: this.y };
+		this.trail.head.x = this.x;
+		this.trail.head.y = this.y;
+		//this._temp[this._temp.length - 1].line.end = { x: this.x, y: this.y };
 	}
 
 	private moveAlongHeading(): void {

--- a/app/raycaster/src/player/player.ts
+++ b/app/raycaster/src/player/player.ts
@@ -51,8 +51,8 @@ class Player implements PlayerInterface {
 
 	move(): void {
 		this.adjustCamera();
-		this.moveAlongHeading();
 		this.redirectIfTurned();
+		this.moveAlongHeading();
 	}
 
 	private turn(dir: Directions): void {

--- a/app/raycaster/src/player/player.ts
+++ b/app/raycaster/src/player/player.ts
@@ -10,7 +10,6 @@ class Player implements PlayerInterface {
 	x: number;
 	y: number;
 	private currentHeading: number;
-	private lastPosition: Coordinates = { x: 0, y: 0 };
 	public color: ColorName;
 	private bMath: BMath = BMath.getInstance();
 	private isTurning: boolean = false;
@@ -25,8 +24,6 @@ class Player implements PlayerInterface {
 		this.x = coordinates.x;
 		this.y = coordinates.y;
 		this.currentHeading = camera.angle;
-		this.lastPosition = { x: this.x, y: this.y };
-		const startWall = { line: { start: this.lastPosition, end: this.lastPosition }, color };
 		this.color = color;
 	}
 

--- a/app/raycaster/src/player/player.ts
+++ b/app/raycaster/src/player/player.ts
@@ -5,11 +5,12 @@ import { WallInterface } from '../gamemap/interface';
 import { BMath } from '../boundedMath/bmath';
 import { CameraInterface } from '../camera/interface';
 import { Directions } from '../controls/directions';
+import { TrailInterface } from '../trail/interface';
 
 class Player implements PlayerInterface {
 	x: number;
 	y: number;
-	private _trail: WallInterface[] = [];
+	private _temp: WallInterface[] = [];
 	private currentHeading: number;
 	private lastPosition: Coordinates = { x: 0, y: 0 };
 	public color: ColorName;
@@ -20,14 +21,15 @@ class Player implements PlayerInterface {
 		coordinates: Coordinates,
 		private speed: number,
 		color: ColorName = ColorName.RED,
-		private camera: CameraInterface
+		private camera: CameraInterface,
+		trail: TrailInterface
 	) {
 		this.x = coordinates.x;
 		this.y = coordinates.y;
 		this.currentHeading = camera.angle;
 		this.lastPosition = { x: this.x, y: this.y };
 		const startWall = { line: { start: this.lastPosition, end: this.lastPosition }, color };
-		this._trail = [startWall];
+		this._temp = [startWall];
 		this.color = color;
 	}
 
@@ -36,7 +38,7 @@ class Player implements PlayerInterface {
 	}
 
 	get trail(): WallInterface[] {
-		return this._trail;
+		return this._temp;
 	}
 
 	turnLeft(): void {
@@ -79,7 +81,7 @@ class Player implements PlayerInterface {
 	}
 
 	private addTrailSegment(): void {
-		this._trail.push({ line: { start: { x: this.x, y: this.y }, end: { x: this.x, y: this.y } }, color: this.color })
+		this._temp.push({ line: { start: { x: this.x, y: this.y }, end: { x: this.x, y: this.y } }, color: this.color })
 	}
 
 	private cameraTurnHasCompleted(): boolean {
@@ -87,7 +89,7 @@ class Player implements PlayerInterface {
 	}
 
 	private growTrail(): void {
-		this._trail[this._trail.length - 1].line.end = { x: this.x, y: this.y };
+		this._temp[this._temp.length - 1].line.end = { x: this.x, y: this.y };
 	}
 
 	private moveAlongHeading(): void {

--- a/app/raycaster/src/player/player.ts
+++ b/app/raycaster/src/player/player.ts
@@ -1,7 +1,6 @@
 import { PlayerInterface } from './interface';
 import { ColorName } from '../color/color_name';
 import { Coordinates } from '../geometry/interfaces';
-import { WallInterface } from '../gamemap/interface';
 import { BMath } from '../boundedMath/bmath';
 import { CameraInterface } from '../camera/interface';
 import { Directions } from '../controls/directions';
@@ -10,7 +9,6 @@ import { TrailInterface } from '../trail/interface';
 class Player implements PlayerInterface {
 	x: number;
 	y: number;
-	private _temp: WallInterface[] = [];
 	private currentHeading: number;
 	private lastPosition: Coordinates = { x: 0, y: 0 };
 	public color: ColorName;
@@ -29,12 +27,7 @@ class Player implements PlayerInterface {
 		this.currentHeading = camera.angle;
 		this.lastPosition = { x: this.x, y: this.y };
 		const startWall = { line: { start: this.lastPosition, end: this.lastPosition }, color };
-		this._temp = [startWall];
 		this.color = color;
-	}
-
-	get temp(): WallInterface[] {
-		return this._temp;
 	}
 
 	get angle(): number {

--- a/app/raycaster/src/player/player.ts
+++ b/app/raycaster/src/player/player.ts
@@ -70,7 +70,7 @@ class Player implements PlayerInterface {
 	}
 
 	private redirect(): void {
-		this.addTrailSegment();
+		this.trail.append(this.x, this.y);
 		this.currentHeading = this.camera.angle;
 	}
 
@@ -78,11 +78,6 @@ class Player implements PlayerInterface {
 		if (this.camera.isRotating) {
 			this.camera.adjust();
 		}
-	}
-
-	private addTrailSegment(): void {
-		this.trail.append(this.x, this.y);
-		//this._temp.push({ line: { start: { x: this.x, y: this.y }, end: { x: this.x, y: this.y } }, color: this.color })
 	}
 
 	private cameraTurnHasCompleted(): boolean {

--- a/app/raycaster/src/player/player.ts
+++ b/app/raycaster/src/player/player.ts
@@ -81,7 +81,8 @@ class Player implements PlayerInterface {
 	}
 
 	private addTrailSegment(): void {
-		this._temp.push({ line: { start: { x: this.x, y: this.y }, end: { x: this.x, y: this.y } }, color: this.color })
+		this.trail.append(this.x, this.y);
+		//this._temp.push({ line: { start: { x: this.x, y: this.y }, end: { x: this.x, y: this.y } }, color: this.color })
 	}
 
 	private cameraTurnHasCompleted(): boolean {

--- a/app/raycaster/src/player/player.ts
+++ b/app/raycaster/src/player/player.ts
@@ -22,7 +22,7 @@ class Player implements PlayerInterface {
 		private speed: number,
 		color: ColorName = ColorName.RED,
 		private camera: CameraInterface,
-		trail: TrailInterface
+		public trail: TrailInterface
 	) {
 		this.x = coordinates.x;
 		this.y = coordinates.y;
@@ -33,12 +33,12 @@ class Player implements PlayerInterface {
 		this.color = color;
 	}
 
-	get angle(): number {
-		return this.camera.angle;
+	get temp(): WallInterface[] {
+		return this._temp;
 	}
 
-	get trail(): WallInterface[] {
-		return this._temp;
+	get angle(): number {
+		return this.camera.angle;
 	}
 
 	turnLeft(): void {

--- a/app/raycaster/src/trail/interface.ts
+++ b/app/raycaster/src/trail/interface.ts
@@ -1,0 +1,17 @@
+import { ColorName } from '../color/color_name';
+
+interface TrailInterface {
+	append(x: number, y: number): void,
+
+	head: TrailSegment
+	tail: TrailSegment
+	color: ColorName
+}
+
+interface TrailSegment {
+	x: number;
+	y: number;
+	next?: TrailSegment;
+}
+
+export { TrailInterface, TrailSegment };

--- a/app/raycaster/src/trail/trail.test.tsx
+++ b/app/raycaster/src/trail/trail.test.tsx
@@ -1,0 +1,11 @@
+import { describe, test, expect } from '@jest/globals';
+import { Trail } from './trail';
+import { ColorName } from '../color/color_name';
+describe('Trail object tests', () => {
+	test('object creation', () => {
+		const trail = new Trail(0, 0, ColorName.RED);
+		expect(trail.head).toEqual({ x: 0, y: 0 });
+		expect(trail.tail).toEqual({ x: 0, y: 0 });
+		expect(trail.color).toEqual(ColorName.RED);
+	})
+})

--- a/app/raycaster/src/trail/trail.test.tsx
+++ b/app/raycaster/src/trail/trail.test.tsx
@@ -8,4 +8,11 @@ describe('Trail object tests', () => {
 		expect(trail.tail).toEqual({ x: 0, y: 0 });
 		expect(trail.color).toEqual(ColorName.RED);
 	})
+	test('object creation', () => {
+		const trail = new Trail(5, 5, ColorName.BLUE);
+		expect(trail.head).toEqual({ x: 5, y: 5 });
+		expect(trail.tail).toEqual({ x: 5, y: 5 });
+		expect(trail.color).toEqual(ColorName.BLUE);
+	})
+
 })

--- a/app/raycaster/src/trail/trail.test.tsx
+++ b/app/raycaster/src/trail/trail.test.tsx
@@ -1,6 +1,7 @@
-import { describe, test, expect } from '@jest/globals';
+import { describe, test, expect, beforeEach } from '@jest/globals';
 import { Trail } from './trail';
 import { ColorName } from '../color/color_name';
+
 describe('Trail object tests', () => {
 	test('object creation', () => {
 		const trail = new Trail(0, 0, ColorName.RED);
@@ -14,5 +15,16 @@ describe('Trail object tests', () => {
 		expect(trail.tail).toEqual({ x: 5, y: 5 });
 		expect(trail.color).toEqual(ColorName.BLUE);
 	})
+})
 
+describe('append test', () => {
+	let trail: Trail;
+	beforeEach(() => {
+		trail = new Trail(0, 0, ColorName.RED);
+	})
+	test('append to trail', () => {
+		trail.append(1, 1);
+		expect(trail.head).toEqual({ x: 1, y: 1 });
+		expect(trail.tail).toEqual({ x: 0, y: 0 });
+	})
 })

--- a/app/raycaster/src/trail/trail.test.tsx
+++ b/app/raycaster/src/trail/trail.test.tsx
@@ -24,7 +24,7 @@ describe('append test', () => {
 	})
 	test('append to trail', () => {
 		trail.append(1, 1);
-		expect(trail.head).toEqual({ x: 1, y: 1 });
-		expect(trail.tail).toEqual({ x: 0, y: 0 });
+		expect(trail.head).toEqual(expect.objectContaining({ x: 1, y: 1 }));
+		expect(trail.tail).toEqual(expect.objectContaining({ x: 0, y: 0 }));
 	})
 })

--- a/app/raycaster/src/trail/trail.ts
+++ b/app/raycaster/src/trail/trail.ts
@@ -9,8 +9,10 @@ class Trail implements TrailInterface {
 		this.head = { x: originX, y: originY };
 		this.tail = { x: originX, y: originY };
 	}
+
 	append(x: number, y: number): void {
-		throw new Error('Method not implemented.');
+		const temp = { x, y, next: this.head };
+		this.head = temp;
 	}
 }
 

--- a/app/raycaster/src/trail/trail.ts
+++ b/app/raycaster/src/trail/trail.ts
@@ -3,9 +3,11 @@ import { ColorName } from '../color/color_name';
 import { TrailSegment } from './interface';
 
 class Trail implements TrailInterface {
-	head: { x: number, y: number } = { x: 0, y: 0 };
-	tail: TrailSegment = this.head;
+	head: TrailSegment;
+	tail: TrailSegment;
 	constructor(originX: number, originY: number, public color: ColorName) {
+		this.head = { x: originX, y: originY };
+		this.tail = { x: originX, y: originY };
 	}
 	append(x: number, y: number): void {
 		throw new Error('Method not implemented.');

--- a/app/raycaster/src/trail/trail.ts
+++ b/app/raycaster/src/trail/trail.ts
@@ -2,10 +2,9 @@ import { TrailInterface } from './interface';
 import { ColorName } from '../color/color_name';
 
 class Trail implements TrailInterface {
-	head: { x: number, y: number } = { x: -1, y: -1 };
-	tail: { x: number, y: number } = { x: -1, y: -1 };
-	constructor(origin: { x: number, y: number }, public color: ColorName) {
-		this.head = this.tail = origin;
+	head: { x: number, y: number } = { x: 0, y: 0 };
+	tail: { x: number, y: number } = { x: 0, y: 0 };
+	constructor(originX: number, originY: number, public color: ColorName) {
 	}
 	append(x: number, y: number): void {
 		throw new Error('Method not implemented.');

--- a/app/raycaster/src/trail/trail.ts
+++ b/app/raycaster/src/trail/trail.ts
@@ -1,0 +1,15 @@
+import { TrailInterface } from './interface';
+import { ColorName } from '../color/color_name';
+
+class Trail implements TrailInterface {
+	head: { x: number, y: number } = { x: -1, y: -1 };
+	tail: { x: number, y: number } = { x: -1, y: -1 };
+	constructor(origin: { x: number, y: number }, public color: ColorName) {
+		this.head = this.tail = origin;
+	}
+	append(x: number, y: number): void {
+		throw new Error('Method not implemented.');
+	}
+}
+
+export { Trail }

--- a/app/raycaster/src/trail/trail.ts
+++ b/app/raycaster/src/trail/trail.ts
@@ -1,9 +1,10 @@
 import { TrailInterface } from './interface';
 import { ColorName } from '../color/color_name';
+import { TrailSegment } from './interface';
 
 class Trail implements TrailInterface {
 	head: { x: number, y: number } = { x: 0, y: 0 };
-	tail: { x: number, y: number } = { x: 0, y: 0 };
+	tail: TrailSegment = this.head;
 	constructor(originX: number, originY: number, public color: ColorName) {
 	}
 	append(x: number, y: number): void {

--- a/app/raycaster/src/worker/worker.ts
+++ b/app/raycaster/src/worker/worker.ts
@@ -31,7 +31,7 @@ onmessage = (e) => {
 		renderer = new Renderer(ctx);
 		const mapSize = { width: msg.settings.CANVAS_WIDTH, height: msg.settings.CANVAS_HEIGHT };
 		const camera = new Camera(msg.settings.TURN_TIME, msg.settings.CAMERA_ANGLE);
-		const trail = new Trail({ x: 10, y: 10 }, msg.settings.PLAYER_COLOR);
+		const trail = new Trail(10, 10, msg.settings.PLAYER_COLOR);
 		player = new Player({ x: 10, y: 10 }, msg.settings.PLAYER_SPEED, msg.settings.PLAYER_COLOR, camera, trail);
 		const map = new GameMap(mapSize, msg.settings.MAP_COLOR, msg.settings.GRID_CELL_SIZE, player);
 

--- a/app/raycaster/src/worker/worker.ts
+++ b/app/raycaster/src/worker/worker.ts
@@ -5,6 +5,7 @@ import { Raycaster } from '../raycaster/raycaster';
 import { Brightness } from '../brightness/brightness';
 import { Player } from '../player/player';
 import { Directions } from '../controls/directions';
+import { Trail } from '../trail/trail';
 import { Camera } from '../camera/camera';
 
 let game: Game;
@@ -30,7 +31,8 @@ onmessage = (e) => {
 		renderer = new Renderer(ctx);
 		const mapSize = { width: msg.settings.CANVAS_WIDTH, height: msg.settings.CANVAS_HEIGHT };
 		const camera = new Camera(msg.settings.TURN_TIME, msg.settings.CAMERA_ANGLE);
-		player = new Player({ x: 10, y: 10 }, msg.settings.PLAYER_SPEED, msg.settings.PLAYER_COLOR, camera);
+		const trail = new Trail({ x: 10, y: 10 }, msg.settings.PLAYER_COLOR);
+		player = new Player({ x: 10, y: 10 }, msg.settings.PLAYER_SPEED, msg.settings.PLAYER_COLOR, camera, trail);
 		const map = new GameMap(mapSize, msg.settings.MAP_COLOR, msg.settings.GRID_CELL_SIZE, player);
 
 		raycaster = new Raycaster(


### PR DESCRIPTION
We're moving towards the use of allocation pools in order to straight up nix or reduce the heap memory deltas that occur during gameplay. We want to control it so we don't allocate more memory than we have to.

changes include defaulting the pool object to use a fixed size and updating game map's cast ray method to expose a slice instead of returning it.