### PR TITLE
Add tap controls

### DIFF
--- a/app/raycaster/src/listener/listener.ts
+++ b/app/raycaster/src/listener/listener.ts
@@ -1,5 +1,5 @@
 import { Directions } from '../controls/directions';
-import { assertIsPositive } from '../utils/utils'
+import { assertIsPositiveInteger } from '../utils/utils'
 
 const type = "turn";
 
@@ -40,9 +40,13 @@ class Listener {
 		// information hidden
 		// preconditions:
 		// the game space is centered in the window
-		assertIsPositive(x);
-		assertIsPositive(windowWidth);
-		// x and windowWidth are positive integers
+		// 		// x and windowWidth are positive integers
+
+		assertIsPositiveInteger(x);
+		assertIsPositiveInteger(windowWidth);
+		if (x > windowWidth) {
+			throw new Error('x coordinate may not be wider than window width')
+		}
 		// postconditions:
 		//		the worker receives a directional message
 	}

--- a/app/raycaster/src/listener/listener.ts
+++ b/app/raycaster/src/listener/listener.ts
@@ -47,6 +47,7 @@ class Listener {
 		if (x > windowWidth) {
 			throw new Error('x coordinate may not be wider than window width')
 		}
+		this.worker.postMessage({ direction: Directions.LEFT })
 		// postconditions:
 		//		the worker receives a directional message
 	}

--- a/app/raycaster/src/listener/listener.ts
+++ b/app/raycaster/src/listener/listener.ts
@@ -28,28 +28,23 @@ class Listener {
 		}
 		this.lastDirection = DirectionRecord.NONE;
 	}
+
 	/**derives the direction based on the click location 
 	 * and posts it to the worker
 	* */
-
-	// click 
 	click(x: number, windowWidth: number) {
-		// hides: 
-		// -- how the turn direction is derived from the click location
-		// takes in the coordinates of the mouse click
-		// information hidden
-		// preconditions:
-		// the game space is centered in the window
-		// 		// x and windowWidth are positive integers
 
 		assertIsPositiveInteger(x);
 		assertIsPositiveInteger(windowWidth);
 		if (x > windowWidth) {
 			throw new Error('x coordinate may not be wider than window width')
 		}
-		// postconditions:
-		//		the worker receives a directional message
-		this.postTurn(DirectionRecord.LEFT)
+		// if x is less than the halfway mark, it's a left turn, otherwise it's a right turn
+		if (x < Math.floor(windowWidth / 2)) {
+			this.postTurn(DirectionRecord.LEFT)
+		} else {
+			this.postTurn(DirectionRecord.RIGHT)
+		}
 	}
 
 	private isLastDirection(keystroke: string): boolean {

--- a/app/raycaster/src/listener/listener.ts
+++ b/app/raycaster/src/listener/listener.ts
@@ -47,9 +47,9 @@ class Listener {
 		if (x > windowWidth) {
 			throw new Error('x coordinate may not be wider than window width')
 		}
-		this.worker.postMessage({ direction: Directions.LEFT })
 		// postconditions:
 		//		the worker receives a directional message
+		this.postTurn(DirectionRecord.LEFT)
 	}
 
 	private isLastDirection(keystroke: string): boolean {
@@ -72,8 +72,24 @@ class Listener {
 
 	private postIfDirectionChanged(direction: DirectionRecord): void {
 		if (direction !== this.lastDirection) {
-			this.worker.postMessage({ type, direction });
+			this.postTurn(direction)
 		}
+	}
+
+	/**
+	 * encapsulates a post for a turn direction
+	 */
+	private postTurn(direction: DirectionRecord) {
+		//assert direction is valid type
+		if (!Object.values(DirectionRecord).includes(direction as DirectionRecord)) {
+			throw new Error(`!{direction} is invalid`)
+		}
+		// exit early if no direction
+		if (direction === DirectionRecord.NONE) {
+			return;
+		}
+		//call worker with type "turn" and appropriate direction
+		this.worker.postMessage({ type: 'turn', direction });
 	}
 }
 

--- a/app/raycaster/src/listener/listener.ts
+++ b/app/raycaster/src/listener/listener.ts
@@ -1,4 +1,5 @@
 import { Directions } from '../controls/directions';
+import { assertIsPositive } from '../utils/utils'
 
 const type = "turn";
 
@@ -26,6 +27,24 @@ class Listener {
 			return;
 		}
 		this.lastDirection = DirectionRecord.NONE;
+	}
+	/**derives the direction based on the click location 
+	 * and posts it to the worker
+	* */
+
+	// click 
+	click(x: number, windowWidth: number) {
+		// hides: 
+		// -- how the turn direction is derived from the click location
+		// takes in the coordinates of the mouse click
+		// information hidden
+		// preconditions:
+		// the game space is centered in the window
+		assertIsPositive(x);
+		assertIsPositive(windowWidth);
+		// x and windowWidth are positive integers
+		// postconditions:
+		//		the worker receives a directional message
 	}
 
 	private isLastDirection(keystroke: string): boolean {

--- a/app/raycaster/src/listener/window_listener.test.tsx
+++ b/app/raycaster/src/listener/window_listener.test.tsx
@@ -33,19 +33,20 @@ describe('click tests', () => {
 			const wrapper = () => { listener.click(x, width) }
 			//asserts if it throws
 			expect(wrapper).toThrow()
-
 		}
 
 	});
 
-	test('callind click with x or width less than 0 should throw', () => {
+	test('calling click with x or width less than 0 should throw', () => {
 		assertThrows(-1, 100)
 		assertThrows(10, -1)
 		expect(() => listener.click(-1, 100)).toThrow()
 		expect(() => listener.click(10, -1)).toThrow()
-	})
-	//calling click with width equal to 0 should throw
-	//calling click with x greater than width should throw
+	});
+
+	test('calling click with x greater than width should throw', () => {
+		assertThrows(40, 39)
+	});
 	// calling click with x less than 1/2 width should post a turn left message
 	// calling click with x greater than 1/2 width should post a turn right message
 	// when width is odd and x is dead center, should default to calling turn right

--- a/app/raycaster/src/listener/window_listener.test.tsx
+++ b/app/raycaster/src/listener/window_listener.test.tsx
@@ -47,7 +47,17 @@ describe('click tests', () => {
 	test('calling click with x greater than width should throw', () => {
 		assertThrows(40, 39)
 	});
-	// calling click with x less than 1/2 width should post a turn left message
+	test("calling click with x less than 1/2 width should post a turn left message", () => {
+		// confirm calling the method with x: 9 and width: 100 does not throw
+		const xCoordinate = 9;
+		const width = 100;
+		expect(() => listener.click(xCoordinate, width)).not.toThrow()
+		// call the method with x: 9 and width :100
+		//confirm the spy was called with type "turn"
+		//confirm the spy was called with turn: "left"
+		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ direction: Directions.LEFT }))
+
+	})
 	// calling click with x greater than 1/2 width should post a turn right message
 	// when width is odd and x is dead center, should default to calling turn right
 })

--- a/app/raycaster/src/listener/window_listener.test.tsx
+++ b/app/raycaster/src/listener/window_listener.test.tsx
@@ -78,7 +78,19 @@ describe('click tests', () => {
 		assertTurnCalledWith(spy, Directions.RIGHT)
 
 	})
-	// when width is odd and x is dead center, should default to calling turn right
+	test("when width is odd and x is dead center, should default to calling turn right", () => {
+		//width is 6, which is odd if include zero index
+		const width = 6
+		//x is 3, which puts coordinates 0, 1, 2, on one side and 4, 5, 6 on the other
+		const x = 3
+		//assumes window displays with upper bound inclusive
+		// assert the method doesn't throw
+		assertDoesntThrow(x, width)
+		// call the method
+		listener.click(x, width)
+		// assert turn is called with right
+		assertTurnCalledWith(spy, Directions.RIGHT)
+	})
 })
 
 describe('Keydown Tests', () => {

--- a/app/raycaster/src/listener/window_listener.test.tsx
+++ b/app/raycaster/src/listener/window_listener.test.tsx
@@ -9,62 +9,31 @@ describe('click tests', () => {
 	let mockWorker: Worker;
 	let listener: Listener;
 	let spy: PostSpy;
-	let assertThrows: Function;
-	let assertDoesntThrow: Function;
-	let assertWrapper: Function;
 
 	beforeEach(() => {
 		mockWorker = createMockWorker()
 		spy = createSpy(mockWorker)
 		listener = new Listener(mockWorker)
-
-		/***
-		 * a couple of DRY functions to encapsulate callbacks
-		 * */
-		assertWrapper = (x: number, width: number) => {
-			return () => { listener.click(x, width) }
-		}
-
-		/**
-		 * encapsulation of confirming method throws
-		 */
-		assertThrows = (x: number, width: number) => {
-			//calls click inside an arrow method
-			const wrapper = assertWrapper(x, width)
-			//asserts if it throws
-			expect(wrapper).toThrow()
-		}
-
-		/**
-		 * encapsulation of confirming method does not throw
-		 */
-		assertDoesntThrow = (x: number, width: number) => {
-			//calls click inside an arrow method
-			const wrapper = assertWrapper(x, width)
-			//asserts if it throws
-			expect(wrapper).not.toThrow()
-
-		}
 	});
 
 	test('calling click with x or width less than 0 should throw', () => {
-		assertThrows(-1, 100)
-		assertThrows(10, -1)
+		assertClickThrows(listener, -1, 100)
+		assertClickThrows(listener, 10, -1)
 	});
 
 	test('calling click with x greater than width should throw', () => {
-		assertThrows(40, 39)
+		assertClickThrows(listener, 40, 39)
 	});
+
 	test("calling click with x less than 1/2 width should post a turn left message", () => {
 		// confirm calling the method with x: 9 and width: 100 does not throw
 		const xCoordinate = 9;
 		const width = 100;
-		assertDoesntThrow(xCoordinate, width)
-		// call the method with x: 9 and width :100
+		assertClickDoesntThrow(listener, xCoordinate, width)
 		listener.click(xCoordinate, width)
 		assertTurnCalledWith(spy, Directions.LEFT)
-
 	})
+
 	test("calling click with x greater than 1/2 width should post a turn right message", () => {
 		// x is 750
 		const x = 750
@@ -72,12 +41,12 @@ describe('click tests', () => {
 		const width = 1000
 
 		// the method should not throw
-		assertDoesntThrow(x, width)
+		assertClickDoesntThrow(listener, x, width)
 		listener.click(x, width)
 		// assert called with right
 		assertTurnCalledWith(spy, Directions.RIGHT)
-
 	})
+
 	test("when width is odd and x is dead center, should default to calling turn right", () => {
 		//width is 6, which is odd if include zero index
 		const width = 6
@@ -85,7 +54,7 @@ describe('click tests', () => {
 		const x = 3
 		//assumes window displays with upper bound inclusive
 		// assert the method doesn't throw
-		assertDoesntThrow(x, width)
+		assertClickDoesntThrow(listener, x, width)
 		// call the method
 		listener.click(x, width)
 		// assert turn is called with right
@@ -114,9 +83,7 @@ describe('Keydown Tests', () => {
 		const keyStroke = 'ArrowLeft';
 		listener.keydown(keyStroke);
 		listener.keydown(keyStroke);
-		expect(postMessageSpy.mock.calls).toEqual([
-			[{ type: 'turn', direction: Directions.LEFT }]
-		]);
+		assertMutlipleTurnsCalledWith(postMessageSpy, [Directions.LEFT])
 	})
 
 	test('should turn right', () => {
@@ -201,3 +168,32 @@ function assertMutlipleTurnsCalledWith(spy: PostSpy, directions: Array<Direction
 	// assert the spy's call array equals the payloads
 	expect(spy.mock.calls).toEqual(payloads)
 }
+
+
+/***
+ * a couple of DRY functions to encapsulate callbacks
+ * */
+function assertClickWrapper(listener: Listener, x: number, width: number): () => void {
+	return () => { listener.click(x, width) }
+}
+
+/**
+ * encapsulation of confirming method throws
+ */
+function assertClickThrows(listener: Listener, x: number, width: number): void {
+	//calls click inside an arrow method
+	const wrapper = assertClickWrapper(listener, x, width)
+	//asserts if it throws
+	expect(wrapper).toThrow()
+}
+
+/**
+ * encapsulation of confirming method does not throw
+ */
+function assertClickDoesntThrow(listener: Listener, x: number, width: number): void {
+	//calls click inside an arrow method
+	const wrapper = assertClickWrapper(listener, x, width)
+	//asserts if it throws
+	expect(wrapper).not.toThrow()
+}
+

--- a/app/raycaster/src/main.ts
+++ b/app/raycaster/src/main.ts
@@ -27,3 +27,13 @@ window.addEventListener("keydown", (e: KeyboardEvent) => {
 window.addEventListener("keyup", (e: KeyboardEvent) => {
 	listener.keyup(e.key);
 });
+
+/**
+ * Handles mouse or tab - based events
+ * **/
+window.addEventListener("click", (e: MouseEvent) => {
+	// clickup not required because click records a full mouse down then mouse up
+	console.log('click detected')
+	// call listener's click method with clientX
+	listener.click(e.clientX, window.innerWidth);
+});

--- a/app/raycaster/src/main.ts
+++ b/app/raycaster/src/main.ts
@@ -32,8 +32,6 @@ window.addEventListener("keyup", (e: KeyboardEvent) => {
  * Handles mouse or tab - based events
  * **/
 window.addEventListener("click", (e: MouseEvent) => {
-	// clickup not required because click records a full mouse down then mouse up
-	console.log('click detected')
-	// call listener's click method with clientX
+	// mouse releage not required because click records a full mouse down then mouse up
 	listener.click(e.clientX, window.innerWidth);
 });


### PR DESCRIPTION
add click detection to the controls. The desired end result is tapping the left or right side of the screen should turn the player left or right